### PR TITLE
coco2custom bug for filenames with "." is fixed. Classes file is not necessary in this conversion

### DIFF
--- a/tools/label_converter.py
+++ b/tools/label_converter.py
@@ -270,7 +270,6 @@ class LabelConverter:
     def coco_to_custom(self, input_file, output_path, image_path):
 
         img_dic = {}
-        print(image_path)
         for file in os.listdir(image_path):
             img_dic[file] = file
 
@@ -289,7 +288,6 @@ class LabelConverter:
 
         # map image_id to info
         for dic_info in data["images"]:
-            #print(img_dic)
             total_info[dic_info["id"]] = {
                 "imageWidth": dic_info["width"],
                 "imageHeight": dic_info["height"],

--- a/tools/label_converter.py
+++ b/tools/label_converter.py
@@ -42,6 +42,8 @@ class LabelConverter:
         if classes_file:
             with open(classes_file, 'r') as f:
                 self.classes = f.read().splitlines()
+        else:
+            self.classes = []
 
     def custom_to_voc2017(self, input_file, output_dir):
         with open(input_file, 'r') as f:
@@ -268,12 +270,16 @@ class LabelConverter:
     def coco_to_custom(self, input_file, output_path, image_path):
 
         img_dic = {}
+        print(image_path)
         for file in os.listdir(image_path):
-            prefix = file.split('.')[0]
-            img_dic[prefix] = file
+            img_dic[file] = file
 
         with open(input_file, 'r', encoding='utf-8') as f:
             data = json.load(f)
+            
+        if not self.classes:
+            for cat in data["categories"]:
+                self.classes.append(cat["name"])
 
         total_info, label_info = {}, {}
 
@@ -283,6 +289,7 @@ class LabelConverter:
 
         # map image_id to info
         for dic_info in data["images"]:
+            #print(img_dic)
             total_info[dic_info["id"]] = {
                 "imageWidth": dic_info["width"],
                 "imageHeight": dic_info["height"],


### PR DESCRIPTION
Hello,

This PR solves the bug of [this](https://github.com/CVHub520/X-AnyLabeling/issues/34) issue.

Additionaly, coco doesn't have a classes file, so it should work without provide any file. This PR  add also that feature.

**Important:** With this PR, polygons will also be converted when using coco2custom function. 

Please, let me know if you need some extra information.

Best,

H.