### PR TITLE
Fix coco label name bug and loading bmp image file bug

### DIFF
--- a/anylabeling/views/labeling/label_converter.py
+++ b/anylabeling/views/labeling/label_converter.py
@@ -459,7 +459,7 @@ class LabelConverter:
 
         for dic_info in data["annotations"]:
             difficult = bool(int(str(dic_info.get("ignore", "0"))))
-            label = self.classes[dic_info["category_id"] - 1]
+            label = label_info[dic_info["category_id"]]
 
             if mode == "rectangle":
                 shape_type = "rectangle"

--- a/anylabeling/views/labeling/label_file.py
+++ b/anylabeling/views/labeling/label_file.py
@@ -49,7 +49,9 @@ class LabelFile:
             # A more efficient solution should be considered in the future.
             from PIL import Image, ExifTags
             with Image.open(filename) as img:
-                exif_data = img._getexif()
+                exif_data=None
+                if hasattr(img, '_getexif'):
+                    exif_data = img._getexif()
                 if exif_data is not None:
                     for tag, value in exif_data.items():
                         tag_name = ExifTags.TAGS.get(tag, tag)


### PR DESCRIPTION
1. When the id of categories in the coco annotation file starts from 0, using `self.classes` will cause errors in obtaining the label name, so it is changed to use `label_info`.
2. 'BmpImageFile' object has no attribute '_getexif'