### PR TITLE
修复无法保存子图且无报错的漏洞

### DIFF
--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -2037,11 +2037,12 @@ class LabelingWidget(LabelDialog):
             )
             if osp.exists(label_file):
                 label_dir_path = dir_path
-        elif self.image_list and not self.output_dir and self.filename:
+        elif self.image_list and self.filename:
             image_file_list = self.image_list
-            label_dir_path = osp.dirname(self.filename)
         if self.output_dir:
             label_dir_path = self.output_dir
+        else:
+            label_dir_path = osp.dirname(self.filename)
         save_path = osp.join(
             osp.dirname(self.filename), "..", "x-anylabeling-crops"
         )


### PR DESCRIPTION
当保存子图前更改了输出目录output_dir会导致image_file_list没有被赋值，一直为空列表，进而导致后文中try的第一个for循环无法正常运行，即无法运行保存子图的核心代码。亲测更改后可以正常保存子图。