### PR TITLE
自动标注的功能扩展, 速度提升等

### DIFF
--- a/anylabeling/app.py
+++ b/anylabeling/app.py
@@ -188,7 +188,7 @@ def main():
     language = config.get("language", QtCore.QLocale.system().name())
     translator = QtCore.QTranslator()
     loaded_language = translator.load(
-        ":/languages/translations/" + language + ".qm"
+        "./resources/translations/" + language + ".qm"
     )
     # Enable scaling for high dpi screens
     QtWidgets.QApplication.setAttribute(

--- a/anylabeling/services/auto_labeling/__base__/yolo.py
+++ b/anylabeling/services/auto_labeling/__base__/yolo.py
@@ -43,6 +43,7 @@ class YOLO(Model):
             "edit_conf",
             "input_iou",
             "edit_iou",
+            "DealFun_combobox",
             "toggle_preserve_existing_annotations",
             "button_reset_tracker",
         ]

--- a/anylabeling/views/labeling/label_converter.py
+++ b/anylabeling/views/labeling/label_converter.py
@@ -429,6 +429,11 @@ class LabelConverter:
             line = line.strip().split(" ")
             class_index = int(line[0])
             label = self.classes[class_index]
+
+            # 由于标定时无需对归并类(gbl)做处理, 故导入时需将归并类去除掉
+            if label.find("(gbl)") != -1:
+                continue
+
             if mode == "hbb":
                 shape_type = "rectangle"
                 cx = float(line[1])
@@ -924,6 +929,17 @@ class LabelConverter:
                     f.write(
                         f"{class_index} {x_center:.6f} {y_center:.6f} {width:.6f} {height:.6f}\n"
                     )
+
+                    # 由于标定时并未对归并类(gbl)做处理; 导出时需将归并类补充上
+                    # 归并类的处理(lunALL(gbl) = lunSingle + lunDouble)
+                    if label == "lunSingle" or label == "lunDouble":
+                        f.write(f"{5} {x_center:.6f} {y_center:.6f} {width:.6f} {height:.6f}\n")
+                    # 归并类的处理(SinglePlate(gbl) = 蓝 + 绿 + 黄 + 黄绿 + 白 + 黑)
+                    if label == "Blue" or label == "Green" or label == "Yellow" or label == "YellowGreen" or label == "White" or label == "Black":
+                        f.write(f"{9} {x_center:.6f} {y_center:.6f} {width:.6f} {height:.6f}\n")
+                    # 归并类的处理(DoublePlate(gbl) = YellowDouble + WhiteDouble)
+                    if label == "YellowDouble" or label == "WhiteDouble":
+                        f.write(f"{10} {x_center:.6f} {y_center:.6f} {width:.6f} {height:.6f}\n")
 
                     is_empty_file = False
                 elif mode == "seg" and shape_type == "polygon":

--- a/anylabeling/views/labeling/label_file.py
+++ b/anylabeling/views/labeling/label_file.py
@@ -33,11 +33,12 @@ class LabelFileError(Exception):
 class LabelFile:
     suffix = ".json"
 
-    def __init__(self, filename=None, image_dir=None):
+    def __init__(self, filename=None, image_dir=None, loadimg=True):
         self.shapes = []
         self.image_path = None
         self.image_data = None
         self.image_dir = image_dir
+        self.load_label_only = not loadimg
         if filename is not None:
             self.load(filename)
         self.filename = filename
@@ -95,14 +96,18 @@ class LabelFile:
                     image_path = osp.join(
                         osp.dirname(filename), data["imagePath"]
                     )
-                image_data = self.load_image_file(image_path)
+                if not self.load_label_only:
+                    image_data = self.load_image_file(image_path)
+                else:
+                    image_data = None
             flags = data.get("flags") or {}
             image_path = data["imagePath"]
-            self._check_image_height_and_width(
-                base64.b64encode(image_data).decode("utf-8"),
-                data.get("imageHeight"),
-                data.get("imageWidth"),
-            )
+            if image_data is not None:
+                self._check_image_height_and_width(
+                    base64.b64encode(image_data).decode("utf-8"),
+                    data.get("imageHeight"),
+                    data.get("imageWidth"),
+                )
             shapes = [Shape().load_from_dict(s) for s in data["shapes"]]
         except Exception as e:  # noqa
             raise LabelFileError(e) from e

--- a/anylabeling/views/labeling/shape.py
+++ b/anylabeling/views/labeling/shape.py
@@ -88,6 +88,9 @@ class Shape:
         self.cache_description = None
         self.visible = True
 
+        self.errorTypeStr = None
+        self.my_index = None
+
         # Rotation setting
         self.direction = direction
         self.center = None

--- a/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
+++ b/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
@@ -123,6 +123,7 @@ class AutoLabelingWidget(QWidget):
             self.cache_auto_label_changed
         )
         self.button_finish_object.setShortcut("F")
+        self.DealFun_combobox.currentIndexChanged.connect(self.on_handleSelectionChange)
         self.toggle_preserve_existing_annotations.stateChanged.connect(
             self.on_preserve_existing_annotations_state_changed
         )
@@ -404,6 +405,7 @@ class AutoLabelingWidget(QWidget):
             "input_iou",
             "output_label",
             "output_select_combobox",
+            "DealFun_combobox",
             "toggle_preserve_existing_annotations",
             "button_reset_tracker",
             "upn_select_combobox",
@@ -430,6 +432,26 @@ class AutoLabelingWidget(QWidget):
     def on_iou_value_changed(self, value):
         self.initial_iou_value = value
         self.model_manager.set_auto_labeling_iou(value)
+
+    def on_handleSelectionChange(self):
+        dealFunFlag = self.DealFun_combobox.currentIndex()
+        self.model_manager.new_auto_labeling_result.disconnect()
+        if dealFunFlag == 0:
+            self.toggle_preserve_existing_annotations.show()
+            self.model_manager.new_auto_labeling_result.connect(
+                lambda auto_labeling_result: self.parent.new_shapes_from_auto_labeling(auto_labeling_result))
+        elif dealFunFlag == 1:
+            self.toggle_preserve_existing_annotations.show()
+            self.model_manager.new_auto_labeling_result.connect(
+                lambda auto_labeling_result: self.parent.new_shapes_from_auto_labeling_Extend(auto_labeling_result))
+        elif dealFunFlag == 2:
+            self.toggle_preserve_existing_annotations.hide()
+            self.model_manager.new_auto_labeling_result.connect(
+                lambda auto_labeling_result: self.parent.new_shapes_from_auto_labeling_FindErr(auto_labeling_result))
+        else:
+            self.toggle_preserve_existing_annotations.hide()
+            self.model_manager.new_auto_labeling_result.connect(
+                lambda auto_labeling_result: self.parent.new_shapes_from_auto_labeling_Erase(auto_labeling_result))
 
     def on_preserve_existing_annotations_state_changed(self, state):
         self.initial_preserve_annotations_state = state
@@ -545,6 +567,7 @@ class AutoLabelingWidget(QWidget):
 
             # Show preserve annotations toggle for all modes
             self.toggle_preserve_existing_annotations.show()
+            self.DealFun_combobox.show()
             # Set the default state for preserve annotations
             if mode in preserve_annotations_modes:
                 # Temporarily disconnect the signal to avoid triggering the callback

--- a/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.ui
+++ b/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.ui
@@ -311,6 +311,36 @@
       </widget>
      </item>
      <item>
+      <widget class="QComboBox" name="DealFun_combobox">
+       <property name="currentText">
+        <string>0-原(批量标定)</string>
+       </property>
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>0-原(批量标定)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>1-新(批量标定)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>2-提取疑错标签</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>3-极小样本擦除</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
       <widget class="QCheckBox" name="toggle_preserve_existing_annotations">
           <property name="text">
               <string>Preserve existing annotations</string>

--- a/anylabeling/views/labeling/widgets/canvas.py
+++ b/anylabeling/views/labeling/widgets/canvas.py
@@ -1336,15 +1336,17 @@ class Canvas(
                         bbox = shape.bounding_rect()
                     except IndexError:
                         continue
+					# 原位置容易遮挡视线，不容易看清边界，故做了调整
+                    pyl = int(bound_rect.height())+5 if bbox.y() > bound_rect.height()+5 else -5
                     rect = QtCore.QRect(
                         int(bbox.x()),
-                        int(bbox.y()),
+                        int(bbox.y() - pyl),
                         int(bound_rect.width()),
                         int(bound_rect.height()),
                     )
                     text_pos = QtCore.QPoint(
                         int(bbox.x()),
-                        int(bbox.y() + bound_rect.height() - d_text),
+                        int(bbox.y() - pyl + bound_rect.height() - d_text),
                     )
                 elif shape.shape_type in [
                     "circle",


### PR DESCRIPTION
0.导出yolo标签时, 背景图要创建一个空文件(因yolo训练时,背景图也需要有对应的标注文件)

1.修改标签显示时的坐标值, 原位置容易遮挡视线，不容易看清边界，故做了调整

2.修改LabelFile类, 可以不加载图片, 只加载label, 提升批量自动标注的运行速度

3.加载语言文件时, 没有发现路径languages/translations/, 但找到了路径resources/translations/, 故改成了这个路径

4.保存子图的改进
	1)将背景图也收集到一起(子图用于发现标定错误的, 背景图用于发现没有标定的)
	2)按权重划分二级文件夹(标定错误的样本, 权重比较低, 只需逐一检查低权重文件夹中的子图, 即可发现标定错误的, 可极大提升人工检查的速度)

5.关于归并类的处理
	说明: 归并类（例如: 动物 = 猫 + 狗)是其它子类的合并， 人工标定时无需关心， 故导入时需过滤掉, 导出时需补充上
	导入导出: 导入时,过滤掉归并类; 导出时,补充上归并类
	自动处理: 标定时,过滤掉归并类; 查错时,要分析归并类, 以便于判定归并类是否有问题

6.将自动推理下的处理任务分拆为四个独立的函数, 并通过下拉框控制当前执行哪个任务
	1)在auto_labeling.ui中增加了一个下拉框，用于选择执行哪个批量处理任务
	2)在auto_labeling.py中添加了对新增下拉框的显示控制和响应事件
	3)给LabelingWidget类增加crop_and_save()函数 和 save_labels_autolabeling()函数
	4)新增的下拉框, 默认选择0, 即: 原来的自动标注功能(保持和原来一样, 未做改动)
	5)新写了:批量自动标定new_shapes_from_auto_labeling_Extend()函数
	6)新写了:提取疑错标签new_shapes_from_auto_labeling_FindErr()函数
	7)新写了:极小样本擦除new_shapes_from_auto_labeling_Erase()函数, 尚未写完

7.进一步对自动推理流程做加速(CPU版在i7-8700K上可以跑到100ms/张了)
	1)对save_labels_autolabeling函数做改进, 最大限度的提升速度
	2)list太慢了, 1万张图耗时约10ms, 为了加速换成了tuple
	3)为了加速, 未使用batch_load_file函数, 而是只加载标签文件
	4)为了关注耗时是否正常, 增加了进度和耗时打印的代码
	5)对new_shapes_from_auto_labeling_Extend函数做了精简, 去掉没用的代码
	6)对new_shapes_from_auto_labeling_FindErr函数做了精简, 去掉没用的代码