### PR TITLE
Fixed the bug about exporting the empty labels

### DIFF
--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -4893,7 +4893,7 @@ class LabelingWidget(LabelDialog):
                 label_file_name = osp.splitext(image_file_name)[0] + ".json"
                 dst_file_name = osp.splitext(image_file_name)[0] + ".txt"
                 dst_file = osp.join(save_path, dst_file_name)
-                src_file = osp.join(label_dir_path, label_file_name)
+                src_file = osp.join(osp.dirname(image_file), label_file_name)
 
                 is_empty_file = converter.custom_to_yolo(
                     src_file, dst_file, mode, skip_empty_files


### PR DESCRIPTION
Hi, thank for your for your good tool. I really like this tool but I found a bug.
If the user's image dataset has many sub folders and they `Open Dir` at root folder, it will produce some empty labels when exporting the labels. 
Take an example below, if your folder structure look like:
```
root/
├── sub1
│   ├── 1.jpg
│   ├── 2.jpg
│   └── 3.jpg
├── sub2
│   ├── 4.jpg
│   ├── 5.jpg
│   └── 6.jpg
└── sub3
    ├── 7.jpg
    ├── 8.jpg
    └── 9.jpg
``` 
if you `Open Dir` at `root` and export the labels, the exported labels of 4.jpg - 9.jpg will be empty, because the variable `label_path_dir` will be `root/sub1` in this example due to the logic of your code. If not found .json file, your code will return empty label. Accordingly, the exported labels of 4.jpg - 9.jpg will be empty. I fixed this bug.