### PR TITLE
mask_import_update

### DIFF
--- a/anylabeling/views/labeling/label_converter.py
+++ b/anylabeling/views/labeling/label_converter.py
@@ -191,12 +191,13 @@ class LabelConverter:
         results = []
         input_type = mapping_table["type"]
         mapping_color = mapping_table["colors"]
-
         if input_type == "grayscale":
             color_to_label = {v: k for k, v in mapping_color.items()}
             binaray_img = cv2.imread(mask, cv2.IMREAD_GRAYSCALE)
             # use the different color_value to find the sub-region for each class
             for color_value in np.unique(binaray_img):
+                if color_value not in color_to_label:
+                    continue
                 class_name = color_to_label.get(color_value, "Unknown")
                 label_map = (binaray_img == color_value).astype(np.uint8)
 
@@ -221,7 +222,6 @@ class LabelConverter:
             }
             rgb_img = cv2.imread(mask)
             hsv_img = cv2.cvtColor(rgb_img, cv2.COLOR_BGR2HSV)
-
             _, binary_img = cv2.threshold(
                 hsv_img[:, :, 1], 0, 255, cv2.THRESH_BINARY
             )
@@ -237,6 +237,8 @@ class LabelConverter:
                 x, y, w, h = cv2.boundingRect(contour)
                 center = (int(x + w / 2), int(y + h / 2))
                 rgb_color = rgb_img[center[1], center[0]].tolist()
+                if rgb_color == [0, 0, 0] and rgb_color not in color_to_label:
+                    continue
                 label = color_to_label.get(tuple(rgb_color[::-1]), "Unknown")
 
                 points = []
@@ -859,7 +861,6 @@ class LabelConverter:
         self, input_file, output_file, image_file, mapping_table
     ):
         self.reset()
-
         results = self.get_contours_and_labels(input_file, mapping_table)
         for result in results:
             shape = {

--- a/anylabeling/views/labeling/utils/upload.py
+++ b/anylabeling/views/labeling/utils/upload.py
@@ -641,9 +641,12 @@ def upload_mask_annotation(self, LABEL_OPACITY):
         for i, image_filename in enumerate(image_file_list):
             if image_filename.endswith(".json"):
                 continue
-            label_filename = osp.splitext(image_filename)[0] + ".png"
             data_filename = osp.splitext(image_filename)[0] + ".json"
-            if label_filename not in label_file_list:
+            if osp.splitext(image_filename)[0] + ".png" in label_file_list:
+                label_filename = osp.splitext(image_filename)[0] + ".png"
+            elif osp.splitext(image_filename)[0] + ".jpg" in label_file_list:
+                label_filename = osp.splitext(image_filename)[0] + ".jpg"
+            else:
                 continue
             input_file = osp.join(label_dir_path, label_filename)
             output_file = osp.join(output_dir_path, data_filename)


### PR DESCRIPTION
在grayscale的json文件并未指定黑色时仍然会生成Unknown类型，给导出Yolo格式带来了额外的工作量，同时掩码中黑白色交界处有灰色会额外产生点状标记，因此修改代码只有在json文件中指定时方才生成对应的标记。
增添grayscale限制黑色后的情况：
![1](https://github.com/user-attachments/assets/bfb7038f-cdaf-4246-845d-419fcf95b506)

掩码图：
![2](https://github.com/user-attachments/assets/f44e5806-6206-45d9-8455-fad09b3ec9ae)

增添grayscale限制未在json文件中指定的颜色：
![3](https://github.com/user-attachments/assets/e858a498-2f34-4215-8878-277356b362fd)

同时在rgb的情况下同样增加对[0, 0, 0]黑色的自动生成，并发现当掩码图格式为jpg时，会无法导入，为此修改upload文件，增加了简单的判断逻辑。

修改以后目前满足了个人掩码导入的需求。

此外还发现会有加载完成的弹窗弹出后方才出现进度条并且进度条不会加载完毕消失，导入后完成并第一时间出现的提示：
![4](https://github.com/user-attachments/assets/169eb836-ac91-4ba0-aa5f-77a1fcc8326d)


但有关进度条的问题未能定位代码位置，需要劳烦作者亲自解决。

希望该pr能够帮助到X-Anylabeling的完善。最后感谢作者的开源贡献！
