### PR TITLE
Fixed failure to click again after custom model loading.

### DIFF
--- a/anylabeling/services/auto_labeling/model_manager.py
+++ b/anylabeling/services/auto_labeling/model_manager.py
@@ -100,9 +100,11 @@ class ModelManager(QObject):
                     model_config["config_file"] = os.path.normpath(
                         os.path.abspath(config_file)
                     )
-            model_config["is_custom_model"] = model.get(
-                "is_custom_model", False
-            )
+            is_custom = model.get("is_custom_model", False)
+            model_config["is_custom_model"] = is_custom
+            if is_custom and not model_config["name"].startswith("_custom_"):
+                model_config["name"] = f"_custom_{model_config["name"]}"
+
             model_configs.append(model_config)
 
         # Sort by last used

--- a/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
+++ b/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
@@ -270,6 +270,9 @@ class AutoLabelingWidget(QWidget):
                 elif not os.path.exists(model_dict["config_path"]):
                     continue
 
+                if not model_name.startswith("_custom_"):
+                    model_name = f"_custom_{model_name}"
+
                 model_data["Custom"][model_name] = {
                     "selected": False,
                     "favorite": model_dict["favorite"],
@@ -380,6 +383,10 @@ class AutoLabelingWidget(QWidget):
                 # update model_info
                 with open(config_file, "r", encoding="utf-8") as f:
                     config_info = yaml.safe_load(f)
+
+                if not config_info["name"].startswith("_custom_"):
+                    config_info["name"] = f"_custom_{config_info['name']}"
+
                 self.model_info[config_info["name"]] = {
                     "display_name": config_info["display_name"],
                     "config_path": config_file,


### PR DESCRIPTION
In the current version, there are some issues with loading custom models. Loading the custom model for the first time via the load_custom_model button is ready to work. But when you click on a loaded model in the list of custom models, the program displays the following message: **Error in loading custom model: Invalid path.**

![2](https://github.com/user-attachments/assets/a4f08eec-582f-4d30-b10b-e198104fb5ff)
![3](https://github.com/user-attachments/assets/3dd4498b-0849-4af7-a34f-ceecbdffa297)


I analyzed the application's logic for loading the custom model and found the cause: When the `name` parameter in the custom model configuration file matches the `name` parameter in the application's embedded model configuration file, some operations in `init_model_data()` can cause the loaded custom model information stored in `self.model_configs` to be overwritten by the embedded model information.

The solution is as simple as adding the `_custom_` flag inside the application to the custom model that the user imports.

I think it's important to differentiate between inline and custom models for the same model, so that we can keep both models of the same type.

I have read and agree to the CLA.
