### PR TITLE
Fix the issue of the scrollbar slider not displaying

### DIFF
--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -232,6 +232,7 @@ class LabelingWidget(LabelDialog):
         file_list_widget = QtWidgets.QWidget()
         file_list_widget.setLayout(file_list_layout)
         self.file_dock.setWidget(file_list_widget)
+        self.file_dock.setStyleSheet("QDockWidget::title {" "text-align: center;" "padding: 0px;" "}")
 
         self.zoom_widget = ZoomWidget()
         self.setAcceptDrops(True)


### PR DESCRIPTION
In some cases, the scrollbar cannot be displayed properly in the image list area.

When I use the software on the embedded screen of my laptop, the scrollbar in that area displays normally.
![2](https://github.com/user-attachments/assets/67af375d-bce4-490b-a0dc-55d6695d6077)

But when I use the software on a larger expanded screen, there is an issue where the scrollbar cannot be displayed properly.
![1](https://github.com/user-attachments/assets/2c3e4478-d2d0-4d82-91ea-61795d64423b)

This issue also existed in previous versions, and now this PR has fixed this problem.



I have read and agree to the CLA.
