### PR TITLE
Fix the issue where modifications cannot be saved

### DIFF
--- a/anylabeling/views/labeling/widgets/canvas.py
+++ b/anylabeling/views/labeling/widgets/canvas.py
@@ -179,6 +179,20 @@ class Canvas(
             self.shapes_backups = self.shapes_backups[-self.num_backups - 1 :]
         self.shapes_backups.append(shapes_backup)
 
+    def store_moving_shape(self):
+        """Store a moving shape"""
+        if self.moving_shape and self.h_hape:
+            index = self.shapes.index(self.h_hape)
+            if (
+                    self.shapes_backups[-1][index].points
+                    != self.shapes[index].points
+            ):
+                self.store_shapes()
+                self.shape_moved.emit()
+
+            self.moving_shape = False
+        pass
+
     @property
     def is_shape_restorable(self):
         """Check if shape can be restored from backup"""
@@ -213,6 +227,7 @@ class Canvas(
 
     def leaveEvent(self, _):
         """Mouse leave event"""
+        self.store_moving_shape()
         self.un_highlight()
         self.restore_cursor()
 
@@ -652,16 +667,7 @@ class Canvas(
                         [x for x in self.selected_shapes if x != self.h_hape]
                     )
 
-        if self.moving_shape and self.h_hape:
-            index = self.shapes.index(self.h_hape)
-            if (
-                self.shapes_backups[-1][index].points
-                != self.shapes[index].points
-            ):
-                self.store_shapes()
-                self.shape_moved.emit()
-
-            self.moving_shape = False
+        self.store_moving_shape()
 
     def end_move(self, copy):
         """End of move"""


### PR DESCRIPTION
When adjusting the target area point position, if the left mouse button is released beyond the canvas area, the view will also display the adjusted point and its connected line at the edge of the canvas, but it is not actually saved. At this point, switch to the next image and then switch back to this image. The adjusted area displays the point position before adjustment.

`Shape that needs to be adjusted.`
![1](https://github.com/user-attachments/assets/4facb1c3-08d6-4c29-8a44-76a05e30549b)

`Release the mouse at the red dot in the image.`
![2](https://github.com/user-attachments/assets/64c33bfc-86f4-4cde-b270-0a54dd0b1cd6)

`After switching the image, when cutting back, the shape has not been adjusted.`
![3](https://github.com/user-attachments/assets/b01f1f44-36cc-47d9-b11a-bcec9d440068)

The reason for this issue is as follows: the operation of store moving shape is detected in the release mouse event of canvas listening, but the behavior of releasing beyond the canvas area cannot be captured normally.
This PR encapsulates the operation of store moving shape into a function, which is added to the canvas listening mouse leaving canvas event to solve this problem.
Shape edge adjustment is common, and it is also common for the mouse to freely move away from the canvas area.

I have read and agree to the CLA.
