### PR TITLE
Fixes the issue where copied shapes fail to be saved

### DIFF
--- a/anylabeling/views/labeling/widgets/canvas.py
+++ b/anylabeling/views/labeling/widgets/canvas.py
@@ -186,14 +186,16 @@ class Canvas(
 
     def store_moving_shape(self):
         """Store a moving shape"""
-        if self.moving_shape and self.h_hape:
-            index = self.shapes.index(self.h_hape)
-            if (
-                    self.shapes_backups[-1][index].points
-                    != self.shapes[index].points
-            ):
-                self.store_shapes()
-                self.shape_moved.emit()
+        if self.moving_shape:
+            for shape in self.selected_shapes:
+                index = self.shapes.index(shape)
+                if (
+                        self.shapes_backups[-1][index].points
+                        != self.shapes[index].points
+                ):
+                    self.store_shapes()
+                    self.shape_moved.emit()
+                    break
 
             self.moving_shape = False
 


### PR DESCRIPTION
When using the keyboard shortcut to copy a shape, the newly created shape overlaps with the original shape. During small positional adjustments in this state, the parameter `self.h_shape` may fail to update in a timely manner, leading to the positional adjustments of the newly created shape failing to be saved.  

This PR optimizes the saving logic when moving shapes and resolves this [issue](https://github.com/CVHub520/X-AnyLabeling/issues/1001).

I have read and agree to the CLA.
