### PR TITLE
修复撤销操作后切换图片时未自动保存的bug，在undo_shape_edit()方法中添加set_dirty()确保撤销操作后文件状态被标…

### DIFF
--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -2109,6 +2109,7 @@ class LabelingWidget(LabelDialog):
         self.label_list.clear()
         self.load_shapes(self.canvas.shapes)
         self.actions.undo.setEnabled(self.canvas.is_shape_restorable)
+        self.set_dirty()
 
     def get_label_file_list(self):
         label_file_list = []


### PR DESCRIPTION
我在使用时认为撤销是会自动保存的（因为标注的物体比较小，ai自动标注后需要拉开一下看是否正确，然后撤回回去）

Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [ ✅ ] I have read and agree to the CLA.
