### PR TITLE
Import error because of version change of supervision package

### DIFF
--- a/anylabeling/services/auto_labeling/yoloe.py
+++ b/anylabeling/services/auto_labeling/yoloe.py
@@ -14,6 +14,7 @@ from .types import AutoLabelingResult
 try:
     import torch
     import supervision as sv
+    
     try:
         from supervision.detection.utils.converters import mask_to_polygons
     except ImportError:


### PR DESCRIPTION
In latest version of supervision package ,**mask_to_polygons** migrated from utils to converters.
so in yoloe.py    
 **from supervision.detection.utils import mask_to_polygons** changes to     **from supervision.detection.utils.converters import mask_to_polygons**




