### PR TITLE
Fix issues when drawing rectangular boxes.

### DIFF
--- a/anylabeling/views/labeling/widgets/canvas.py
+++ b/anylabeling/views/labeling/widgets/canvas.py
@@ -651,6 +651,7 @@ class Canvas(
                         self.create_mode
                         in ["rectangle", "rotation", "circle", "line", "point"]
                         and not self.is_auto_labeling
+                        and not self.current
                     ):
                         self.mode_changed.emit()
                 elif not self.out_off_pixmap(pos):


### PR DESCRIPTION
If the label editing window that appears is directly closed when the drawing of a rectangular box is finished, the lines in the drawing mode will remain displayed on the canvas. The cause of this problem is related to the mode - switching logic and the change of the value of the `self.current` variable.
I have adjusted the mode - switching logic. If the user directly closes the label editing window that appears, the drawing mode will be maintained, allowing them to continue adjusting the size and position of the shape.

I have read and agree to the CLA.
