### PR TITLE
Fix the issue of dragging and moving the image.

### DIFF
--- a/anylabeling/views/labeling/widgets/canvas.py
+++ b/anylabeling/views/labeling/widgets/canvas.py
@@ -733,6 +733,7 @@ class Canvas(
                         and not self.is_auto_labeling
                         and not self.current
                     ):
+                        self.prev_pan_point = ev.localPos()
                         self.mode_changed.emit()
                 elif not self.out_off_pixmap(pos):
                     # Handle auto decode mode first click


### PR DESCRIPTION
When the function of automatically using the label of the previous shape is enabled, if you drag the image right after completing a shape, an abnormal movement issue will occur.

I have read and agree to the CLA.
