### PR TITLE
create_yolo_dataset: ensure train/val split is truly randomized

### DIFF
--- a/anylabeling/services/auto_training/ultralytics/general.py
+++ b/anylabeling/services/auto_training/ultralytics/general.py
@@ -2,6 +2,7 @@ import json
 import os
 import re
 import shutil
+import random 
 from datetime import datetime
 from typing import List
 
@@ -117,6 +118,9 @@ def create_yolo_dataset(
         except Exception:
             background_images.append(image_file)
             continue
+
+    # ensure train/val split is randomized
+    valid_images = random.sample(valid_images, k=len(valid_images))
 
     train_count = int(len(valid_images) * dataset_ratio)
     train_valid_images = valid_images[:train_count]


### PR DESCRIPTION
Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [x] I have read and agree to the CLA.

The current 'create_yolo_dataset' function splits the dataset into training and validation subsets without shuffling. This PR fixed the issure .