### PR TITLE
🐛 fix(label_converter): skip empty lines in label processing to preve…

### DIFF
--- a/anylabeling/views/labeling/label_converter.py
+++ b/anylabeling/views/labeling/label_converter.py
@@ -464,6 +464,8 @@ class LabelConverter:
         img_w, img_h = self.get_image_size(image_file)
         for line in lines:
             line = line.strip().split(" ")
+            if len(line) <= 1:
+                continue
             class_index = int(line[0])
             label = self.classes[class_index]
             shape_type = "rotation"
@@ -508,6 +510,8 @@ class LabelConverter:
         classes = list(self.pose_classes.keys())
         for i, line in enumerate(lines):
             line = line.strip().split(" ")
+            if len(line) <= 1:
+                continue
             class_index = int(line[0])
             label = classes[class_index]
             # Add rectangle info
@@ -576,6 +580,8 @@ class LabelConverter:
         image_size = np.array([img_w, img_h], np.float64)
         for line in lines:
             line = line.strip().split(" ")
+            if len(line) <= 1:
+                continue
             class_index = int(line[0])
             label = self.classes[class_index]
             if mode == "hbb":


### PR DESCRIPTION
Fix the error that occurs when loading YOLO label files containing empty lines.

Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [x] I have read and agree to the CLA.
