### PR TITLE
fix: 'gbk' codec decode error on windows

### DIFF
--- a/anylabeling/services/auto_training/ultralytics/trainer.py
+++ b/anylabeling/services/auto_training/ultralytics/trainer.py
@@ -136,7 +136,8 @@ if __name__ == "__main__":
                         [sys.executable, script_path],
                         stdout=subprocess.PIPE,
                         stderr=subprocess.STDOUT,
-                        universal_newlines=True,
+                        text=True,
+                        encoding="utf-8",
                         bufsize=1,
                         preexec_fn=os.setsid if os.name != "nt" else None,
                     )


### PR DESCRIPTION
Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [x] I have read and agree to the CLA.

When I try the build-in Ultralytics Training Platforms, I encountered a coding problem.

```
Removed existing directory: C:\Users\...\xanylabeling_data/trainer/ultralytics\runs\detect\exp
正在准备训练...
Created dataset: C:\Users\...\xanylabeling_data/trainer/ultralytics\datasets\detect\data_20250914_113018
Training command: yolo detect train data=C:\Users\...\xanylabeling_data/trainer/ultralytics\datasets\detect\data_20250914_113018\data.yaml model=C:/Users/.../Downloads/yolo11n.yaml project=C:\Users\...\xanylabeling_data/trainer/ultralytics\runs\detect name=exp device=[0] classes=None
训练即将开始...
New https://pypi.org/project/ultralytics/8.3.199 available  Update with 'pip install -U ultralytics'
Ultralytics 8.3.190  Python-3.12.11 torch-2.8.0+cu129 CUDA:0 (NVIDIA GeForce RTX 5060 Ti, 16311MiB)
engine\trainer: agnostic_nms=False, amp=True, augment=False, auto_augment=randaugment, batch=16, bgr=0.0, box=7.5, cache=False, cfg=None, classes=None, close_mosaic=10, cls=0.5, conf=None, copy_paste=0.0, copy_paste_mode=flip, cos_lr=False, cutmix=0.0, data=C:\Users\...\xanylabeling_data/trainer/ultralytics\datasets\detect\data_20250914_113018\data.yaml, degrees=0.0, deterministic=True, device=0, dfl=1.5, dnn=False, dropout=0.0, dynamic=False, embed=None, epochs=100, erasing=0.4, exist_ok=False, fliplr=0.5, flipud=0.0, format=torchscript, fraction=1.0, freeze=None, half=False, hsv_h=0.015, hsv_s=0.7, hsv_v=0.4, imgsz=640, int8=False, iou=0.7, keras=False, kobj=1.0, line_width=None, lr0=0.01, lrf=0.01, mask_ratio=4, max_det=300, mixup=0.0, mode=train, model=C:/Users/.../Downloads/yolo11n.yaml, momentum=0.937, mosaic=1.0, multi_scale=False, name=exp, nbs=64, nms=False, opset=None, optimize=False, optimizer=auto, overlap_mask=True, patience=100, perspective=0.0, plots=True, pose=12.0, pretrained=True, profile=False, project=C:\Users\...\xanylabeling_data/trainer/ultralytics\runs\detect, rect=False, resume=False, retina_masks=False, save=True, save_conf=False, save_crop=False, save_dir=C:\Users\...\xanylabeling_data\trainer\ultralytics\runs\detect\exp, save_frames=False, save_json=False, save_period=-1, save_txt=False, scale=0.5, seed=0, shear=0.0, show=False, show_boxes=True, show_conf=True, show_labels=True, simplify=True, single_cls=False, source=None, split=val, stream_buffer=False, task=detect, time=None, tracker=botsort.yaml, translate=0.1, val=True, verbose=False, vid_stride=1, visualize=False, warmup_bias_lr=0.1, warmup_epochs=3.0, warmup_momentum=0.8, weight_decay=0.0005, workers=8, workspace=None
from  n    params  module                                       arguments
0                  -1  1       464  ultralytics.nn.modules.conv.Conv             [3, 16, 3, 2]
1                  -1  1      4672  ultralytics.nn.modules.conv.Conv             [16, 32, 3, 2]
2                  -1  1      6640  ultralytics.nn.modules.block.C3k2            [32, 64, 1, False, 0.25]
3                  -1  1     36992  ultralytics.nn.modules.conv.Conv             [64, 64, 3, 2]
4                  -1  1     26080  ultralytics.nn.modules.block.C3k2            [64, 128, 1, False, 0.25]
5                  -1  1    147712  ultralytics.nn.modules.conv.Conv             [128, 128, 3, 2]
6                  -1  1     87040  ultralytics.nn.modules.block.C3k2            [128, 128, 1, True]
7                  -1  1    295424  ultralytics.nn.modules.conv.Conv             [128, 256, 3, 2]
8                  -1  1    346112  ultralytics.nn.modules.block.C3k2            [256, 256, 1, True]
9                  -1  1    164608  ultralytics.nn.modules.block.SPPF            [256, 256, 5]
10                  -1  1    249728  ultralytics.nn.modules.block.C2PSA           [256, 256, 1]
11                  -1  1         0  torch.nn.modules.upsampling.Upsample         [None, 2, 'nearest']
12             [-1, 6]  1         0  ultralytics.nn.modules.conv.Concat           [1]
13                  -1  1    111296  ultralytics.nn.modules.block.C3k2            [384, 128, 1, False]
14                  -1  1         0  torch.nn.modules.upsampling.Upsample         [None, 2, 'nearest']
15             [-1, 4]  1         0  ultralytics.nn.modules.conv.Concat           [1]
16                  -1  1     32096  ultralytics.nn.modules.block.C3k2            [256, 64, 1, False]
17                  -1  1     36992  ultralytics.nn.modules.conv.Conv             [64, 64, 3, 2]
18            [-1, 13]  1         0  ultralytics.nn.modules.conv.Concat           [1]
19                  -1  1     86720  ultralytics.nn.modules.block.C3k2            [192, 128, 1, False]
20                  -1  1    147712  ultralytics.nn.modules.conv.Conv             [128, 128, 3, 2]
21            [-1, 10]  1         0  ultralytics.nn.modules.conv.Concat           [1]
22                  -1  1    378880  ultralytics.nn.modules.block.C3k2            [384, 256, 1, True]
23        [16, 19, 22]  1    431257  ultralytics.nn.modules.head.Detect           [3, [64, 128, 256]]
YOLO11n summary: 181 layers, 2,590,425 parameters, 2,590,409 gradients, 6.4 GFLOPs
Freezing layer 'model.23.dfl.conv.weight'
AMP: running Automatic Mixed Precision (AMP) checks...
AMP: checks passed
train: Fast image access  (ping: 0.00.0 ms, read: 2338.21053.3 MB/s, size: 160.5 KB)
train: Scanning C:\Users\...\xanylabeling_data\trainer\ultralytics\datasets\detect\data_20250914_113018\labels\train... 24 images, 0 backgrounds, 0 corrupt: 100% 鈹佲攣鈹佲攣鈹佲攣鈹佲攣鈹佲攣鈹佲攣 24/24 3950.8it/s 0.0s
train: Scanning C:\Users\...\xanylabeling_data\trainer\ultralytics\datasets\detect\data_20250914_113018\labels\train... 24 images, 0 backgrounds, 0 corrupt: 100% 鈹佲攣鈹佲攣鈹佲攣鈹佲攣鈹佲攣鈹佲攣 24/24 3950.8it/s 0.0s
train: New cache created: C:\Users\...\xanylabeling_data\trainer\ultralytics\datasets\detect\data_20250914_113018\labels\train.cache
val: Fast image access  (ping: 0.00.0 ms, read: 3460.3777.3 MB/s, size: 180.7 KB)
val: Scanning C:\Users\...\xanylabeling_data\trainer\ultralytics\datasets\detect\data_20250914_113018\labels\val... 6 images, 0 backgrounds, 0 corrupt: 100% 鈹佲攣鈹佲攣鈹佲攣鈹佲攣鈹佲攣鈹佲攣 6/6 2994.9it/s 0.0s
val: Scanning C:\Users\...\xanylabeling_data\trainer\ultralytics\datasets\detect\data_20250914_113018\labels\val... 6 images, 0 backgrounds, 0 corrupt: 100% 鈹佲攣鈹佲攣鈹佲攣鈹佲攣鈹佲攣鈹佲攣 6/6 2994.9it/s 0.0s
val: New cache created: C:\Users\...\xanylabeling_data\trainer\ultralytics\datasets\detect\data_20250914_113018\labels\val.cache
Plotting labels to C:\Users\...\xanylabeling_data\trainer\ultralytics\runs\detect\exp\labels.jpg...
optimizer: 'optimizer=auto' found, ignoring 'lr0=0.01' and 'momentum=0.937' and determining best 'optimizer', 'lr0' and 'momentum' automatically...
optimizer: AdamW(lr=0.001429, momentum=0.9) with parameter groups 81 weight(decay=0.0), 88 weight(decay=0.0005), 87 bias(decay=0.0)
Image sizes 640 train, 640 val
Using 8 dataloader workers
Logging results to C:\Users\...\xanylabeling_data\trainer\ultralytics\runs\detect\exp
Starting training for 100 epochs...
Epoch    GPU_mem   box_loss   cls_loss   dfl_loss  Instances       Size
ERROR: 'gbk' codec can't decode byte 0x80 in position 88: illegal multibyte sequence
```

According to my search, without specifying enconding, `universal_newlines=True` will use OS default encoding. So I add `encoding="utf-8"`, and replace `universal_newlines` with new `text` (Python 3.7+) by the way. It works well on my windows.