### PR TITLE
fix windows path separator error in train_script.py & add support for path wrapped in quotes for model and data

### DIFF
--- a/anylabeling/services/auto_training/ultralytics/trainer.py
+++ b/anylabeling/services/auto_training/ultralytics/trainer.py
@@ -99,12 +99,8 @@ if __name__ == "__main__":
     signal.signal(signal.SIGINT, signal_handler)
 
     try:
-        model = YOLO('"""
-                + str(train_args.pop("model"))
-                + """')
-        train_args = """
-                + str(train_args)
-                + """
+        model = YOLO({repr(train_args.pop("model"))})
+        train_args = {repr(train_args)}
         train_args['verbose'] = False
         train_args['show'] = False
         results = model.train(**train_args)
@@ -112,7 +108,7 @@ if __name__ == "__main__":
         print("Training interrupted by user", flush=True)
         sys.exit(1)
     except Exception as e:
-        print(f"Training error: {e}", flush=True)
+        print(f"Training error: {{e}}", flush=True)
         sys.exit(1)
 """
             )

--- a/anylabeling/views/training/ultralytics_dialog.py
+++ b/anylabeling/views/training/ultralytics_dialog.py
@@ -985,8 +985,8 @@ class UltralyticsDialog(QDialog):
             "basic": {
                 "project": get_widget_value("project"),
                 "name": get_widget_value("name"),
-                "model": get_widget_value("model"),
-                "data": get_widget_value("data"),
+                "model": get_widget_value("model").strip('"'),
+                "data": get_widget_value("data").strip('"'),
                 "device": get_widget_value("device"),
                 "dataset_ratio": (
                     get_widget_value("dataset_ratio") / 100.0


### PR DESCRIPTION
Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [x] I have read and agree to the CLA.

Copying a windows path with backslash separators and pasting it into the ‘Model’ input box in the built-in Ultralytics Training Platforms will result in an error.

```
正在准备训练...
Created dataset: C:\Users\...\xanylabeling_data/trainer/ultralytics\datasets\detect\data_20250915_190923
Training command: yolo detect train data=C:\Users\...\xanylabeling_data/trainer/ultralytics\datasets\detect\data_20250915_190923\data.yaml model=C:\Users\...\Downloads\yolo11n.yaml project=C:\Users\...\xanylabeling_data/trainer/ultralytics\runs\detect name=exp1 device=[0] classes=None
训练即将开始...
File "C:\Users\...\xanylabeling_data/trainer/ultralytics\runs\detect\train_script.py", line 30
model = YOLO('C:\Users\...\Downloads\yolo11n.yaml')
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: (unicode error) 'unicodeescape' codec can't decode bytes in position 2-3: truncated \UXXXXXXXX escape
ERROR: Training process exited with code 1
```

In addition, windows 11 provides a copy path feature in the right-click menu, it copies the path wrapped in quotes. Although this is not the standard path format, it can sometimes be more convenient to accept this format directly when pasting it into the "Model" or "Data" input box.