### PR TITLE
fix(shape.py): gui crashes due to empty self.points

### DIFF
--- a/anylabeling/views/labeling/shape.py
+++ b/anylabeling/views/labeling/shape.py
@@ -396,6 +396,8 @@ class Shape:
 
     def make_path(self):
         """Create a path from shape"""
+        if not self.points:
+            return QtGui.QPainterPath()
         if self.shape_type == "rectangle":
             path = QtGui.QPainterPath(self.points[0])
             for p in self.points[1:]:


### PR DESCRIPTION
Hey thanks a lot for this amazing labeling tool!

The client GUI sometimes crashes because the `self.points` is empty.

A quick fix is proposed as this PR.

It would be very appreciated for the author to find the root cause and give a proper fix.

> Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:
- [x] I have read and agree to the CLA.
