### PR TITLE
fix: 修复自动标注后切换模式时GUI偶发崩溃的问题

### DIFF
--- a/anylabeling/views/labeling/shape.py
+++ b/anylabeling/views/labeling/shape.py
@@ -249,7 +249,12 @@ class Shape:
             vrtx_path = QtGui.QPainterPath()
 
             if self.shape_type == "rectangle":
-                assert len(self.points) in [1, 2, 4]
+                if len(self.points) not in [1, 2, 4]:
+                    logger.error(
+                        f"Invalid points count for rectangle: "
+                        f"expected 1, 2 or 4, got {len(self.points)}"
+                    )
+                    return
                 if len(self.points) == 2:
                     rectangle = self.get_rect_from_line(*self.points)
                     line_path.addRect(rectangle)
@@ -262,7 +267,12 @@ class Shape:
                     if self.is_closed() or self.label is not None:
                         line_path.lineTo(self.points[0])
             elif self.shape_type == "rotation":
-                assert len(self.points) in [1, 2, 4]
+                if len(self.points) not in [1, 2, 4]:
+                    logger.error(
+                        f"Invalid points count for rotation: "
+                        f"expected 1, 2 or 4, got {len(self.points)}"
+                    )
+                    return
                 if len(self.points) == 2:
                     rectangle = self.get_rect_from_line(*self.points)
                     line_path.addRect(rectangle)
@@ -275,7 +285,12 @@ class Shape:
                     if self.is_closed() or self.label is not None:
                         line_path.lineTo(self.points[0])
             elif self.shape_type == "circle":
-                assert len(self.points) in [1, 2]
+                if len(self.points) not in [1, 2]:
+                    logger.error(
+                        f"Invalid points count for circle: "
+                        f"expected 1 or 2, got {len(self.points)}"
+                    )
+                    return
                 if len(self.points) == 2:
                     rectangle = self.get_circle_rect_from_line(self.points)
                     line_path.addEllipse(rectangle)
@@ -288,7 +303,12 @@ class Shape:
                     line_path.lineTo(p)
                     self.draw_vertex(vrtx_path, i)
             elif self.shape_type == "point":
-                assert len(self.points) == 1
+                if len(self.points) != 1:
+                    logger.error(
+                        f"Invalid points count for point: "
+                        f"expected 1, got {len(self.points)}"
+                    )
+                    return
                 self.draw_vertex(vrtx_path, 0, True)
             else:
                 line_path.moveTo(self.points[0])


### PR DESCRIPTION

## 问题描述
开启自动标注结束后，使用快捷键(1/2/3等)切换标注模式进行手动标注时，点击画布后偶发性出现报错：
Traceback (most recent call last): File "...\canvas.py", line 1628, in paintEvent self.line.paint(p) File "...\shape.py", line 291, in paint assert len(self.points) == 1 AssertionError

## 根本原因
状态不同步导致的竞态条件：
- 切换模式时 已更新为新类型（如 "point"）
- 但 points列表尚未同步为对应数量
- paint()方法中的 `assert` 语句在此时失败

## 解决方案
将 paint() 方法中的 `assert` 断言替换为防御性检查，若 points数量不符合预期则跳过本次绘制。

这是安全的修改，因为：
1. 仅影响临时绘制状态，不影响持久化数据
2. 下一帧渲染时状态会同步完成，正常显示
3. 用户无法感知跳过的这一帧

## 验证
- [x] 该问题已解决，无法复现原崩溃
- [x] 正常标注功能不受影响