### PR TITLE
fix several bugs about the update of attributes panel

### DIFF
--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -2481,7 +2481,7 @@ class LabelingWidget(LabelDialog):
             self.canvas.select_shapes([])
             self.select_toggle_button.setText(self.tr("Select"))
 
-    def reset_attribute(self, text):
+    def reset_attribute(self, text, shape):
         # Skip validation for auto-labeling special constants
         if text in [
             AutoLabelingMode.OBJECT,
@@ -2503,6 +2503,9 @@ class LabelingWidget(LabelDialog):
                 ).format(text, valid_labels, most_similar_label),
             )
             text = most_similar_label
+
+        new_attributes = {attrs_key: attrs_val[0] for attrs_key, attrs_val in self.attributes[text].items()}
+        shape.attributes = new_attributes
         return text
 
     def current_item(self):
@@ -3066,7 +3069,7 @@ class LabelingWidget(LabelDialog):
 
         for shape in shapes:
             if self.attributes and text:
-                text = self.reset_attribute(text)
+                text = self.reset_attribute(text, shape)
 
             shape.label = text
             shape.flags = flags
@@ -3150,7 +3153,7 @@ class LabelingWidget(LabelDialog):
             )
             return
         if self.attributes and text:
-            text = self.reset_attribute(text)
+            text = self.reset_attribute(text, shape)
         shape.label = text
         shape.flags = flags
         shape.group_id = group_id
@@ -3186,7 +3189,11 @@ class LabelingWidget(LabelDialog):
         self.set_dirty()
         self.update_combo_box()
         self.update_gid_box()
-
+        
+        # update top-right attributes panel
+        selected_idx = self.canvas.shapes.index(selected_shapes[0])
+        self.update_attributes(selected_idx)
+        
     def file_search_changed(self):
         search_text = self.file_search.text()
         self.import_image_folder(
@@ -3235,6 +3242,7 @@ class LabelingWidget(LabelDialog):
                 self.canvas.shapes[i].attributes = {}
             self.canvas.shapes[i].attributes[property] = option
             self.save_attributes(self.canvas.shapes)
+            self.canvas.update()
 
     def update_selected_options(self, selected_options):
         if not isinstance(selected_options, dict):
@@ -4064,7 +4072,7 @@ class LabelingWidget(LabelDialog):
             return
 
         if self.attributes and text:
-            text = self.reset_attribute(text)
+            text = self.reset_attribute(text, shape)
 
         if text:
             self.label_list.clearSelection()
@@ -5652,7 +5660,7 @@ class LabelingWidget(LabelDialog):
             return
 
         if self.attributes and text:
-            text = self.reset_attribute(text)
+            text = self.reset_attribute(text, shape)
 
         # Add to label history
         self.label_dialog.add_label_history(text)


### PR DESCRIPTION
Fix [issue 1300](https://github.com/CVHub520/X-AnyLabeling/issues/1300)

We should update attributes panel after we finished the editing of a shape. We also should show the newest attribute right after we finished the editing of attributes panel.

Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [-] I have read and agree to the CLA.
