### PR TITLE
Fix: Restore CUDA device detection after ONNX export in Ultralytics training platform

### DIFF
--- a/anylabeling/services/auto_training/ultralytics/exporter.py
+++ b/anylabeling/services/auto_training/ultralytics/exporter.py
@@ -351,6 +351,9 @@ class ExportManager:
                 sys.stdout = original_stdout
                 sys.stderr = original_stderr
 
+                if os.environ.get("CUDA_VISIBLE_DEVICES") == "":
+                    del os.environ["CUDA_VISIBLE_DEVICES"]
+
         except Exception as e:
             self.notify_callbacks(
                 "export_error",


### PR DESCRIPTION
Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [x] I have read and agree to the CLA.

### Problem Description

After using the Ultralytics training platform to train a model and exporting it to ONNX format, CUDA GPU 0 can't be used in the next training.

1. Device dropdown shows "CUDA" but no GPU 0 checkbox appears below it
2. Training actually uses CPU instead of CUDA
3. torch.cuda.device_count() returns 0

### Steps to Reproduce

1. Open Ultralytics training platform
2. Train a model using GPU (CUDA)
3. Export the trained model to ONNX format
4. Close the training dialog
5. Switch image path folder
6. Reopen Ultralytics training platform
7. Observe: Device shows "CUDA" but no GPU options are available

### Root Cause Analysis

The issue is caused by Ultralytics YOLO library's behavior during ONNX export:

https://github.com/ultralytics/ultralytics/tree/main/ultralytics/engine/exporter.py#L383

```
self.device = select_device("cpu" if self.args.device is None else self.args.device)
```

https://github.com/ultralytics/ultralytics/tree/main/ultralytics/utils/torch_utils.py#L184-L185

```
if cpu or mps:
    os.environ["CUDA_VISIBLE_DEVICES"] = ""
```

And it causes the problem, in the next training, CUDA_VISIBLE_DEVICES is "", so only CPU is used.
