### PR TITLE
🐛 fix(sam2): prevent GPU VRAM leak during interactive segmentation

### DIFF
--- a/anylabeling/services/auto_labeling/__base__/sam2.py
+++ b/anylabeling/services/auto_labeling/__base__/sam2.py
@@ -76,17 +76,49 @@ class SegmentAnything2ONNX:
         return np.array(output_masks)
 
 
+def _create_session(path: str, device: str) -> ort.InferenceSession:
+    """Create an ONNX Runtime inference session with proper GPU memory management.
+
+    This factory function configures the CUDA execution provider with memory
+    limits and a conservative arena allocation strategy to prevent unbounded
+    GPU VRAM growth during repeated inference calls.
+
+    Args:
+        path (str): Path to the ONNX model file.
+        device (str): Device to run inference on ('gpu' or 'cpu').
+
+    Returns:
+        ort.InferenceSession: Configured inference session.
+    """
+    sess_options = ort.SessionOptions()
+    sess_options.log_severity_level = 3
+    sess_options.enable_mem_pattern = True
+    sess_options.enable_mem_reuse = True
+
+    if device.lower() == "gpu":
+        cuda_provider_options = {
+            "device_id": 0,
+            "gpu_mem_limit": 4 * 1024 * 1024 * 1024,
+            "arena_extend_strategy": "kSameAsRequested",
+            "cudnn_conv_algo_search": "DEFAULT",
+        }
+        providers = [
+            ("CUDAExecutionProvider", cuda_provider_options),
+            "CPUExecutionProvider",
+        ]
+    else:
+        providers = ["CPUExecutionProvider"]
+
+    session = ort.InferenceSession(
+        path, providers=providers, sess_options=sess_options
+    )
+    return session
+
+
 class SAM2ImageEncoder:
     def __init__(self, path: str, device: str) -> None:
         # Initialize model
-        providers = ["CPUExecutionProvider"]
-        if device.lower() == "gpu":
-            providers = ["CUDAExecutionProvider"]
-        sess_options = ort.SessionOptions()
-        sess_options.log_severity_level = 3
-        self.session = ort.InferenceSession(
-            path, providers=providers, sess_options=sess_options
-        )
+        self.session = _create_session(path, device)
 
         # Get model info
         self.get_input_details()
@@ -158,14 +190,7 @@ class SAM2ImageDecoder:
         mask_threshold: float = 0.0,
     ) -> None:
         # Initialize model
-        providers = ["CPUExecutionProvider"]
-        if device.lower() == "gpu":
-            providers = ["CUDAExecutionProvider"]
-        sess_options = ort.SessionOptions()
-        sess_options.log_severity_level = 3
-        self.session = ort.InferenceSession(
-            path, providers=providers, sess_options=sess_options
-        )
+        self.session = _create_session(path, device)
 
         self.orig_im_size = (
             orig_im_size if orig_im_size is not None else encoder_input_size

--- a/anylabeling/services/auto_labeling/segment_anything_2.py
+++ b/anylabeling/services/auto_labeling/segment_anything_2.py
@@ -97,8 +97,11 @@ class SegmentAnything2(Model):
         self.marks = []
 
         # Cache for image embedding
-        self.cache_size = 10
-        self.preloaded_size = self.cache_size - 3
+        # NOTE: Cache size reduced to limit GPU VRAM accumulation.
+        # The CUDA arena allocator retains memory from each encoder call,
+        # so fewer cached embeddings = less peak VRAM usage.
+        self.cache_size = 3
+        self.preloaded_size = 1
         self.image_embedding_cache = LRUCache(self.cache_size)
 
         # Pre-inference worker
@@ -449,22 +452,12 @@ class SegmentAnything2(Model):
 
     def on_next_files_changed(self, next_files):
         """
-        Handle next files changed. This function can preload next files
-        and run inference to save time for user.
+        Handle next files changed.
+
+        NOTE: Background preloading is disabled to prevent GPU VRAM leak.
+        The ONNX Runtime CUDA arena allocator grows with each encoder call
+        from the background thread and never releases memory, eventually
+        exhausting all available VRAM. Encoding is now performed on-demand
+        when each image is accessed, with results cached for re-use.
         """
-        if (
-            self.pre_inference_thread is None
-            or not self.pre_inference_thread.isRunning()
-        ):
-            self.pre_inference_thread = QThread()
-            self.pre_inference_worker = GenericWorker(
-                self.preload_worker, next_files
-            )
-            self.pre_inference_worker.finished.connect(
-                self.pre_inference_thread.quit
-            )
-            self.pre_inference_worker.moveToThread(self.pre_inference_thread)
-            self.pre_inference_thread.started.connect(
-                self.pre_inference_worker.run
-            )
-            self.pre_inference_thread.start()
+        pass


### PR DESCRIPTION
## Problem

When using SAM2 models (e.g., `sam2_hiera_large`) with `CUDAExecutionProvider` for interactive segmentation, **GPU VRAM grows unboundedly** after labeling approximately 10 images. Eventually, it exhausts all available VRAM, causing the application to freeze completely (stuck in inference spinner, 99% GPU memory usage). The only recovery is to kill and restart the application.

**Environment:**
- GPU: NVIDIA RTX 4080 Super (16GB VRAM)
- Image size: 640×640
- Model: SAM2.1 Hiera Large (encoder: 848MB ONNX)
- OS: Windows 11
- ONNX Runtime: GPU build with CUDAExecutionProvider

## Root Cause

1. **ONNX Runtime CUDA Arena Allocator** — The default arena strategy (`kNextPowerOfTwo`) aggressively pre-allocates GPU memory in power-of-2 chunks and **never releases it back to the system**, even after inference completes. Each encoder call can trigger arena growth.

2. **Background preload thread** — `on_next_files_changed()` spawns a background thread that continuously runs the encoder on upcoming images (up to 7 ahead). Each background encoding call expands the CUDA arena further, compounding the leak.

3. **Large cache amplifies the issue** — With `cache_size=10` and `preloaded_size=7`, the background thread performs many encoder passes before the user even views those images, rapidly filling VRAM.

## Fix

**`anylabeling/services/auto_labeling/__base__/sam2.py`:**
- Added `_create_session()` factory function that configures `CUDAExecutionProvider` with:
  - `gpu_mem_limit`: 4GB hard cap (prevents unbounded growth)
  - `arena_extend_strategy`: `"kSameAsRequested"` (allocates only the exact amount needed, no speculative pre-allocation)
  - `cudnn_conv_algo_search`: `"DEFAULT"` (avoids extra memory from algorithm search)
  - CPU fallback provider for graceful degradation
- Both `SAM2ImageEncoder` and `SAM2ImageDecoder` now use this function

**`anylabeling/services/auto_labeling/segment_anything_2.py`:**
- Reduced `cache_size` from 10 → 3 (current image + small buffer)
- Reduced `preloaded_size` from 7 → 1
- Disabled background preloading in `on_next_files_changed()` to prevent arena growth from concurrent encoder calls

## Trade-off

Disabling preloading introduces a brief delay (~1-2s) when switching to a new image for the first encoder pass. Subsequent interactions with the same image hit the cache instantly. This is a worthwhile trade-off compared to the previous behavior of freezing after ~10 images.

## Testing

Tested on RTX 4080 Super (16GB VRAM) with **100+ consecutive 640×640 images**:
- **Before fix:** VRAM fills to 99% after ~10 images, application freezes
- **After fix:** Peak VRAM usage stays **below 30%** (~4.5GB) indefinitely, smooth operation throughout the entire session

---

- [x] I have read and agree to the CLA.