### PR TITLE
Fix out-of-bounds OBB export handling

### DIFF
--- a/anylabeling/views/labeling/label_converter.py
+++ b/anylabeling/views/labeling/label_converter.py
@@ -1282,8 +1282,10 @@ class LabelConverter:
                 elif mode == "obb" and shape_type == "rotation":
                     label = shape["label"]
                     points = shape["points"]
-                    if not any(
-                        0 <= p[0] < image_width and 0 <= p[1] < image_height
+                    if any(
+                    # if not any(
+                        # 0 <= p[0] < image_width and 0 <= p[1] < image_height
+                        p[0] < 0 or p[0] > image_width or p[1] < 0 or p[1] > image_height
                         for p in points
                     ):
                         logger.warning(


### PR DESCRIPTION
- 导出存在逻辑错误
  本意为如果有超出边界的框，则跳过。但代码逻辑为:"没有一个点在图像范围内，则跳过"，导致即使超出边界，但只要有点在图像范围内，也会保留。

```python
# 原代码
if not any(
    0 <= p[0] < image_width and 0 <= p[1] < image_height
    for p in points
):
    logger.warning(
        f"{data['imagePath']}: Skip out of bounds coordinates of {points}!"
    )
    continue
...

# 修改后
if any(
    p[0] < 0 or p[0] > image_width or p[1] < 0 or p[1] > image_height
    for p in points
):
    logger.warning(
        f"{data['imagePath']}: Skip out of bounds coordinates of {points}!"
    )
    continue
...
```
- 其他错误 
  本文件中其他类似逻辑，也存在同样错误。

Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [√] I have read and agree to the CLA.
