### PR TITLE
fix: pass all training params to ultralytics, exclude internal-only p…

### DIFF
--- a/anylabeling/services/auto_training/ultralytics/exporter.py
+++ b/anylabeling/services/auto_training/ultralytics/exporter.py
@@ -47,7 +47,7 @@ def validate_onnx_export_environment():
     required_packages = ["onnx", "onnxslim", "onnxruntime"]
     missing_packages = []
     package_mapping = {
-        "onnx": "onnx>=1.12.0,<1.18.0",
+        "onnx": "onnx>=1.15.0",
         "onnxslim": "onnxslim>=0.1.59",
         "onnxruntime": "onnxruntime",
     }
@@ -63,8 +63,8 @@ def validate_onnx_export_environment():
             onnx_version = onnx.__version__
             from packaging import version
 
-            if version.parse(onnx_version) >= version.parse("1.18.0"):
-                missing_packages.append("onnx>=1.12.0,<1.18.0")
+            if version.parse(onnx_version) < version.parse("1.15.0"):
+                missing_packages.append("onnx>=1.15.0")
     except:
         pass
 

--- a/anylabeling/views/training/ultralytics_dialog.py
+++ b/anylabeling/views/training/ultralytics_dialog.py
@@ -1823,13 +1823,11 @@ class UltralyticsDialog(QDialog):
                 "checkpoint",
             ]:
                 advanced_params.update(config.get(section, {}))
-            advanced_params = {
-                key: value
-                for key, value in advanced_params.items()
-                if key in DEFAULT_TRAINING_CONFIG
-                and value != DEFAULT_TRAINING_CONFIG[key]
-            }
-            train_args.update(advanced_params)
+            # Exclude X-AnyLabeling specific parameters not recognized by ultralytics
+            xany_params_to_exclude = {"skip_empty_files", "only_checked_files"}
+            for key, value in advanced_params.items():
+                if key not in xany_params_to_exclude:
+                    train_args[key] = value
             self.total_epochs = train_args.get("epochs", 100)
 
             # Log the training command


### PR DESCRIPTION
Problem: when training with train dialog, if user set imgz to 640(UI default), imgz is not passed to ultralytics resulting ultralytics to use imgz value 1024 instead of 640

- Remove filtering logic that excluded imgsz when it matched UI defaults
- Exclude X-AnyLabeling specific params (skip_empty_files, only_checked_files)

Fixes training configuration mismatch where imgsz=640 in UI was being ignored

Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [✓] I have read and agree to the CLA.
