### PR TITLE
fix(label_list): emit reorder only after completed drops

### DIFF
--- a/anylabeling/views/labeling/widgets/label_list_widget.py
+++ b/anylabeling/views/labeling/widgets/label_list_widget.py
@@ -101,26 +101,17 @@ class LabelListWidgetItem(QtGui.QStandardItem):
         return f'{self.__class__.__name__}("{self.text()!r}")'
 
 
-class StandardItemModel(QtGui.QStandardItemModel):
-    itemDropped = QtCore.pyqtSignal()
-
-    # QT Overload
-    def removeRows(self, *args, **kwargs):
-        ret = super().removeRows(*args, **kwargs)
-        self.itemDropped.emit()
-        return ret
-
-
 class LabelListWidget(QtWidgets.QListView):
     item_double_clicked = QtCore.pyqtSignal(LabelListWidgetItem)
     item_selection_changed = QtCore.pyqtSignal(list, list)
+    item_dropped = QtCore.pyqtSignal()
 
     def __init__(self):
         super().__init__()
         self._selected_items = []
 
         self.setWindowFlags(Qt.WindowType.Window)
-        self.setModel(StandardItemModel())
+        self.setModel(QtGui.QStandardItemModel())
         self.model().setItemPrototype(LabelListWidgetItem())
         self.setItemDelegate(HTMLDelegate())
         self.setSelectionMode(
@@ -130,6 +121,7 @@ class LabelListWidget(QtWidgets.QListView):
             QtWidgets.QAbstractItemView.DragDropMode.InternalMove
         )
         self.setDefaultDropAction(Qt.DropAction.MoveAction)
+        self.setDragDropOverwriteMode(False)
 
         self.doubleClicked.connect(self.item_double_clicked_event)
         self.selectionModel().selectionChanged.connect(
@@ -145,10 +137,6 @@ class LabelListWidget(QtWidgets.QListView):
     def __iter__(self):
         for i in range(len(self)):
             yield self[i]
-
-    @property
-    def item_dropped(self):
-        return self.model().itemDropped
 
     @property
     def item_changed(self):
@@ -179,6 +167,11 @@ class LabelListWidget(QtWidgets.QListView):
     def remove_item(self, item):
         index = self.model().indexFromItem(item)
         self.model().removeRows(index.row(), 1)
+
+    def dropEvent(self, event):
+        super().dropEvent(event)
+        if event.source() is self and event.isAccepted():
+            self.item_dropped.emit()
 
     def select_item(self, item):
         index = self.model().indexFromItem(item)

--- a/tests/test_label_list_widget.py
+++ b/tests/test_label_list_widget.py
@@ -1,0 +1,61 @@
+import os
+import importlib.util
+from pathlib import Path
+import unittest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+try:
+    from PyQt6 import QtWidgets
+
+    PYQT_AVAILABLE = True
+except Exception:
+    PYQT_AVAILABLE = False
+
+
+if PYQT_AVAILABLE:
+    MODULE_PATH = (
+        Path(__file__).resolve().parents[1]
+        / "anylabeling"
+        / "views"
+        / "labeling"
+        / "widgets"
+        / "label_list_widget.py"
+    )
+    MODULE_SPEC = importlib.util.spec_from_file_location(
+        "test_label_list_widget_module", MODULE_PATH
+    )
+    MODULE = importlib.util.module_from_spec(MODULE_SPEC)
+    assert MODULE_SPEC.loader is not None
+    MODULE_SPEC.loader.exec_module(MODULE)
+    LabelListWidget = MODULE.LabelListWidget
+    LabelListWidgetItem = MODULE.LabelListWidgetItem
+
+
+@unittest.skipUnless(
+    PYQT_AVAILABLE, "PyQt6 is required for label list widget tests"
+)
+class TestLabelListWidget(unittest.TestCase):
+
+    def setUp(self):
+        self.app = QtWidgets.QApplication.instance()
+        if self.app is None:
+            self.app = QtWidgets.QApplication([])
+
+    def test_remove_item_does_not_emit_item_dropped(self):
+        widget = LabelListWidget()
+        for name in ["car", "bus", "truck"]:
+            widget.add_iem(LabelListWidgetItem(name, shape=name))
+
+        dropped = []
+        widget.item_dropped.connect(lambda: dropped.append(True))
+
+        widget.remove_item(widget[1])
+
+        self.assertEqual(dropped, [])
+        self.assertEqual([widget[i].text() for i in range(len(widget))], ["car", "truck"])
+
+    def test_internal_move_uses_insert_mode_instead_of_overwrite(self):
+        widget = LabelListWidget()
+
+        self.assertFalse(widget.dragDropOverwriteMode())


### PR DESCRIPTION
- [x] I have read and agree to the CLA.

## Summary
- fix the object list reorder signal so it only fires after a completed internal drop
- disable overwrite-mode drops in the object list to avoid replacing items when dropping onto another object
- add regression tests for non-drop removals and drag/drop configuration

## Verification
- `pytest -q tests/test_label_list_widget.py`

## Notes
- this addresses issue #1385 (`在右侧列表拖动多个对象时会导致闪退`)
- wider UI test imports are currently blocked in this environment by a pre-existing `onnxruntime` access violation during package initialization on Windows
