### PR TITLE
fix(device): isolate ONNX provider probing

### DIFF
--- a/anylabeling/app.py
+++ b/anylabeling/app.py
@@ -1,4 +1,5 @@
 import os
+import json
 
 # Temporary fix for: bus error
 # Source: https://stackoverflow.com/questions/73072612/
@@ -17,6 +18,18 @@ import multiprocessing
 
 import sys
 from pathlib import Path
+
+
+if len(sys.argv) > 1 and sys.argv[1] == "probe-device":
+    try:
+        import onnxruntime as ort
+
+        providers = list(ort.get_available_providers())
+    except Exception:
+        providers = []
+    print(json.dumps({"providers": providers}))
+    sys.exit(0)
+
 
 sys.path.append(str(Path(__file__).resolve().parent.parent))
 

--- a/anylabeling/views/common/device_manager.py
+++ b/anylabeling/views/common/device_manager.py
@@ -1,10 +1,82 @@
 import os
+import json
 import logging
+import pathlib
+import subprocess
+import sys
 from typing import Literal, Optional
 
 logger = logging.getLogger(__name__)
 
 DeviceType = Literal["CPU", "GPU", "AUTO"]
+_PROVIDER_PROBE_TIMEOUT = 5
+
+
+def _build_probe_command() -> list[str]:
+    """Build the hidden CLI command used for safe device probing."""
+    if getattr(sys, "frozen", False):
+        return [sys.executable, "probe-device"]
+    app_path = pathlib.Path(__file__).resolve().parents[2] / "app.py"
+    return [sys.executable, str(app_path), "probe-device"]
+
+
+def _subprocess_kwargs() -> dict:
+    """Extra kwargs for subprocess calls to avoid console windows."""
+    kwargs = {}
+    if sys.platform.startswith("win") and hasattr(
+        subprocess, "CREATE_NO_WINDOW"
+    ):
+        kwargs["creationflags"] = subprocess.CREATE_NO_WINDOW
+    return kwargs
+
+
+def _probe_onnx_providers(timeout: int = _PROVIDER_PROBE_TIMEOUT) -> list[str]:
+    """Safely probe available ONNX Runtime providers in a child process."""
+    command = _build_probe_command()
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+            **_subprocess_kwargs(),
+        )
+    except subprocess.TimeoutExpired:
+        logger.warning(
+            "ONNX provider probe timed out. Falling back to CPU mode."
+        )
+        return []
+    except OSError as e:
+        logger.warning(
+            "ONNX provider probe failed to start: %s. Falling back to CPU mode.",
+            e,
+        )
+        return []
+
+    if completed.returncode != 0:
+        logger.warning(
+            "ONNX provider probe crashed with exit code %s. "
+            "Falling back to CPU mode.",
+            completed.returncode,
+        )
+        return []
+
+    output = completed.stdout.strip()
+    if not output:
+        logger.debug("ONNX provider probe exited cleanly without payload.")
+        return []
+
+    try:
+        payload = json.loads(output)
+    except json.JSONDecodeError:
+        logger.warning(
+            "ONNX provider probe returned invalid JSON. Falling back to CPU mode."
+        )
+        return []
+
+    providers = payload.get("providers", [])
+    return providers if isinstance(providers, list) else []
 
 
 class DeviceManager:
@@ -62,9 +134,7 @@ class DeviceManager:
     def _is_gpu_available(self) -> bool:
         if self._available_providers is None:
             try:
-                import onnxruntime as ort
-
-                self._available_providers = ort.get_available_providers()
+                self._available_providers = _probe_onnx_providers()
             except Exception as e:
                 logger.debug(f"Failed to get ONNX providers: {e}")
                 self._available_providers = []

--- a/tests/test_device_manager.py
+++ b/tests/test_device_manager.py
@@ -1,0 +1,112 @@
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest import mock
+import subprocess
+
+
+MODULE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "anylabeling"
+    / "views"
+    / "common"
+    / "device_manager.py"
+)
+SPEC = importlib.util.spec_from_file_location("device_manager_module", MODULE_PATH)
+DEVICE_MANAGER_MODULE = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(DEVICE_MANAGER_MODULE)
+
+
+class TestDeviceManager(unittest.TestCase):
+    def setUp(self):
+        DEVICE_MANAGER_MODULE.DeviceManager._instance = None
+
+    def test_auto_detect_prefers_gpu_when_cuda_provider_exists(self):
+        manager = DEVICE_MANAGER_MODULE.DeviceManager()
+        with mock.patch.object(
+            DEVICE_MANAGER_MODULE,
+            "_probe_onnx_providers",
+            return_value=["CPUExecutionProvider", "CUDAExecutionProvider"],
+        ):
+            self.assertEqual(manager.get_device(), "GPU")
+            self.assertEqual(manager.get_available_devices(), ["CPU", "GPU"])
+
+    def test_auto_detect_falls_back_to_cpu_when_probe_fails(self):
+        manager = DEVICE_MANAGER_MODULE.DeviceManager()
+        with mock.patch.object(
+            DEVICE_MANAGER_MODULE,
+            "_probe_onnx_providers",
+            return_value=[],
+        ):
+            self.assertEqual(manager.get_device(), "CPU")
+            self.assertEqual(manager.get_available_devices(), ["CPU"])
+
+    def test_available_providers_are_cached_after_first_probe(self):
+        manager = DEVICE_MANAGER_MODULE.DeviceManager()
+        with mock.patch.object(
+            DEVICE_MANAGER_MODULE,
+            "_probe_onnx_providers",
+            return_value=["CUDAExecutionProvider"],
+        ) as probe:
+            self.assertTrue(manager._is_gpu_available())
+            self.assertTrue(manager._is_gpu_available())
+        self.assertEqual(probe.call_count, 1)
+
+    def test_probe_returns_payload_from_successful_worker(self):
+        completed = subprocess.CompletedProcess(
+            args=["probe-device"],
+            returncode=0,
+            stdout='{"providers": ["CUDAExecutionProvider"]}',
+            stderr="",
+        )
+        with mock.patch.object(
+            DEVICE_MANAGER_MODULE.subprocess,
+            "run",
+            return_value=completed,
+        ):
+            providers = DEVICE_MANAGER_MODULE._probe_onnx_providers(timeout=1)
+        self.assertEqual(providers, ["CUDAExecutionProvider"])
+
+    def test_probe_returns_empty_list_when_worker_times_out(self):
+        with mock.patch.object(
+            DEVICE_MANAGER_MODULE.subprocess,
+            "run",
+            side_effect=subprocess.TimeoutExpired(cmd=["probe-device"], timeout=1),
+        ):
+            providers = DEVICE_MANAGER_MODULE._probe_onnx_providers(timeout=1)
+        self.assertEqual(providers, [])
+
+    def test_probe_returns_empty_list_when_worker_crashes(self):
+        completed = subprocess.CompletedProcess(
+            args=["probe-device"],
+            returncode=1,
+            stdout="",
+            stderr="boom",
+        )
+        with mock.patch.object(
+            DEVICE_MANAGER_MODULE.subprocess,
+            "run",
+            return_value=completed,
+        ):
+            providers = DEVICE_MANAGER_MODULE._probe_onnx_providers(timeout=1)
+        self.assertEqual(providers, [])
+
+    def test_probe_returns_empty_list_when_worker_returns_invalid_json(self):
+        completed = subprocess.CompletedProcess(
+            args=["probe-device"],
+            returncode=0,
+            stdout="not-json",
+            stderr="",
+        )
+        with mock.patch.object(
+            DEVICE_MANAGER_MODULE.subprocess,
+            "run",
+            return_value=completed,
+        ):
+            providers = DEVICE_MANAGER_MODULE._probe_onnx_providers(timeout=1)
+        self.assertEqual(providers, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- [x] I have read and agree to the CLA.

## Summary
- move ONNX Runtime provider probing into a hidden child command instead of importing it in the main process
- fall back to CPU cleanly when provider probing times out, crashes, or returns invalid output
- add regression coverage for successful probes, failures, timeouts, invalid payloads, and provider caching

## Verification
- `pytest -q tests/test_device_manager.py`
- `python -c "...module._probe_onnx_providers(timeout=3)..."` (confirmed the probe returns safely in this Windows environment)

## Notes
- this addresses the crash pattern reported in #1386 when opening AI model selection on Windows GPU builds
- it also hardens startup and `checks`-style device queries against ONNX Runtime import crashes in the parent process
