### PR TITLE
Security: Potential Command Injection via os.system

### DIFF
--- a/scripts/compile_languages.py
+++ b/scripts/compile_languages.py
@@ -54,8 +54,12 @@ def compile_resources(output: str, qrc: str) -> None:
 supported_languages = ["en_US", "zh_CN", "ja_JP", "ko_KR"]
 
 for language in supported_languages:
-    command = f"lrelease anylabeling/resources/translations/{language}.ts"
-    os.system(command)
+    subprocess.run(
+        [
+            "lrelease",
+            f"anylabeling/resources/translations/{language}.ts",
+        ]
+    )
 
 compile_resources(
     output="anylabeling/resources/resources.py",


### PR DESCRIPTION
## Problem

The scripts/compile_languages.py file uses os.system() with a formatted string that includes user-controlled input (language variable). Although the language values are from a predefined list, this pattern is dangerous and could lead to command injection if the list is ever modified or if the variable is controlled externally.

**Severity**: `high`
**File**: `scripts/compile_languages.py`

## Solution

Replace os.system() with subprocess.run() using a list of arguments instead of string formatting to prevent command injection. Example: subprocess.run(['lrelease', f'anylabeling/resources/translations/{language}.ts'])

## Changes

- `scripts/compile_languages.py` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced
