### PR TITLE
对越界的obb添加一个显著提示

### DIFF
--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -5591,6 +5591,12 @@ class LabelingWidget(LabelDialog):
                         **default_flags,
                         **shape.flags,
                     }
+
+                shape.oop = any(
+                    p.x() < 0 or p.x() > self.canvas.pixmap.width() or p.y() < 0 or p.y() > self.canvas.pixmap.height()
+                    for p in shape.points
+                )
+
             self.load_shapes(self.label_file.shapes, update_last_label=False)
             if self.label_file.flags is not None:
                 flags.update(self.label_file.flags)

--- a/anylabeling/views/labeling/shape.py
+++ b/anylabeling/views/labeling/shape.py
@@ -424,6 +424,7 @@ class Shape:
             if self.difficult and self.shape_type != "point":
                 pen.setStyle(QtCore.Qt.PenStyle.DashLine)
             if self.oop and self.shape_type == "rotation":
+                pen.setStyle(QtCore.Qt.PenStyle.DashDotLine)
                 pen.setColor(QtGui.QColor("#FF0000"))
             painter.setPen(pen)
 

--- a/anylabeling/views/labeling/shape.py
+++ b/anylabeling/views/labeling/shape.py
@@ -92,6 +92,7 @@ class Shape:
         self.fill = False
         self.hovered = False
         self.selected = False
+        self.oop = False
         self.shape_type = shape_type
         self.flags = flags
         self.other_data = {}
@@ -422,6 +423,8 @@ class Shape:
             pen.setWidth(max(1, int(round(self.line_width / self.scale))))
             if self.difficult and self.shape_type != "point":
                 pen.setStyle(QtCore.Qt.PenStyle.DashLine)
+            if self.oop and self.shape_type == "rotation":
+                pen.setColor(QtGui.QColor("#FF0000"))
             painter.setPen(pen)
 
             line_path = QtGui.QPainterPath()

--- a/anylabeling/views/labeling/widgets/canvas.py
+++ b/anylabeling/views/labeling/widgets/canvas.py
@@ -2156,6 +2156,12 @@ class Canvas(
             shape[lindex] = p2
             shape[rindex] = p4
             shape.close()
+
+            shape.oop = any(
+                p.x() < 0 or p.x() > self.pixmap.width() or p.y() < 0 or p.y() > self.pixmap.height()
+                for p in shape.points
+            )
+
         elif shape.shape_type == "rectangle":
             shift_pos = pos - point
             shape.move_vertex_by(index, shift_pos)
@@ -2205,6 +2211,12 @@ class Canvas(
         if dp:
             for shape in shapes:
                 shape.move_by(dp)
+
+                shape.oop = any(
+                        p.x() < 0 or p.x() > self.pixmap.width() or p.y() < 0 or p.y() > self.pixmap.height()
+                        for p in shape.points
+                )
+
             self.prev_point = pos
             return True
         return False


### PR DESCRIPTION
当前，obb标注时是允许越界的（超出图像范围），但转换时，又强制跳过越界目标。

我这里尝试过，将obb移出allowed_oop_shape_types列表进行限制，但由于obb的特殊性，移动vertex或移动shape，都会涉及到cos计算，得到一个近似值，这个值往往会出现-0.06类似的小负数，在图像上无法通过肉眼识别。

----

- 这个更新主要是对越界的obb添加一个显著提示，方便用户进行检查，不影响其他功能；
- 在性能上，判断均添加到原有循环中，尽量减少额外计算，对性能影响微乎其微。
- 在视觉上，提示采用#ff0000的DashDotLine，区别于difficult的DashLine，以及标签的纯色边框。
- 整个提示，涉及到shape新添加的oop字段，在加载以及移动shape和vertex时会动态更新。

<img width="920" height="610" alt="image" src="https://github.com/user-attachments/assets/bcc24dfb-f2de-48dc-8cfa-c268d88ba3ce" />

Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [√] I have read and agree to the CLA.


