### PR TITLE
🚀 feat(canvas): add bottom-left sliders for label opacity and image b…

### DIFF
--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -70,6 +70,7 @@ from .widgets import (
     AutoLabelingWidget,
     BrightnessContrastDialog,
     Canvas,
+    CanvasAdjustmentWidget,
     ChatbotDialog,
     ClassifierDialog,
     CompareViewManager,
@@ -436,6 +437,20 @@ class LabelingWidget(LabelDialog):
         scroll_area = QScrollArea()
         scroll_area.setWidget(self.canvas)
         scroll_area.setWidgetResizable(True)
+        self._canvas_scroll_area = scroll_area
+
+        # Adjustment panel docked at the bottom-left of the canvas viewport.
+        self.canvas_adjustment = CanvasAdjustmentWidget(scroll_area.viewport())
+        self.canvas_adjustment.opacity_changed.connect(
+            self._on_shape_opacity_changed
+        )
+        self.canvas_adjustment.brightness_contrast_changed.connect(
+            self._on_inline_brightness_contrast
+        )
+        # Hidden until an image is loaded (shown at the end of load_file).
+        self.canvas_adjustment.hide()
+        scroll_area.viewport().installEventFilter(self)
+
         self.scroll_bars = {
             Qt.Orientation.Vertical: scroll_area.verticalScrollBar(),
             Qt.Orientation.Horizontal: scroll_area.horizontalScrollBar(),
@@ -2970,6 +2985,8 @@ class LabelingWidget(LabelDialog):
         self.label_file = None
         self.other_data = {}
         self.canvas.reset_state()
+        if hasattr(self, "canvas_adjustment"):
+            self.canvas_adjustment.hide()
         self.compare_view_manager.reset()
         self.label_filter_combobox.text_box.clear()
         self.gid_filter_combobox.gid_box.clear()
@@ -5615,6 +5632,52 @@ class LabelingWidget(LabelDialog):
             QtGui.QPixmap.fromImage(qimage), clear_shapes=False
         )
 
+    def _on_shape_opacity_changed(self, value):
+        """Update label/shape opacity from the slider value (0-100)."""
+        self.canvas.shape_opacity = value / 100.0
+        self.canvas.update()
+
+    def _on_inline_brightness_contrast(self, brightness, contrast):
+        """Apply brightness/contrast from the inline adjustment sliders.
+
+        Reuses ``brightness_contrast_dialog`` so 16-bit grayscale handling is
+        shared with the menu-driven dialog. ``dialog.img`` is refreshed on
+        every image load (see ``load_file``).
+        """
+        if self.image_data is None or self.filename is None:
+            return
+        dialog = self.brightness_contrast_dialog
+        dialog.slider_brightness.blockSignals(True)
+        dialog.slider_contrast.blockSignals(True)
+        dialog.slider_brightness.setValue(brightness)
+        dialog.slider_contrast.setValue(contrast)
+        dialog.slider_brightness.blockSignals(False)
+        dialog.slider_contrast.blockSignals(False)
+        dialog.on_new_value()
+        self.brightness_contrast_values[self.filename] = (brightness, contrast)
+
+    def _position_canvas_adjustment(self):
+        """Keep the adjustment panel anchored to the viewport's bottom-left."""
+        if not hasattr(self, "canvas_adjustment"):
+            return
+        viewport = self._canvas_scroll_area.viewport()
+        self.canvas_adjustment.adjustSize()
+        margin = 10
+        height = self.canvas_adjustment.height()
+        self.canvas_adjustment.move(
+            margin, max(0, viewport.height() - height - margin)
+        )
+        self.canvas_adjustment.raise_()
+
+    def eventFilter(self, obj, event):
+        if (
+            hasattr(self, "_canvas_scroll_area")
+            and obj is self._canvas_scroll_area.viewport()
+            and event.type() == QtCore.QEvent.Type.Resize
+        ):
+            self._position_canvas_adjustment()
+        return super().eventFilter(obj, event)
+
     def brightness_contrast(self, _):
         self.brightness_contrast_dialog.update_image(
             utils.img_data_to_pil(self.image_data)
@@ -5635,6 +5698,8 @@ class LabelingWidget(LabelDialog):
         brightness = self.brightness_contrast_dialog.slider_brightness.value()
         contrast = self.brightness_contrast_dialog.slider_contrast.value()
         self.brightness_contrast_values[self.filename] = (brightness, contrast)
+        # Keep the inline adjustment sliders in sync with the dialog.
+        self.canvas_adjustment.set_brightness_contrast(brightness, contrast)
 
     def hide_selected_polygons(self):
         shapes_to_hide = []
@@ -5876,19 +5941,25 @@ class LabelingWidget(LabelDialog):
                 self.recent_files[0], (None, None)
             )
         self.brightness_contrast_values[self.filename] = (brightness, contrast)
-        if brightness is not None or contrast is not None:
-            self.brightness_contrast_dialog.update_image(
-                utils.img_data_to_pil(self.image_data)
+        # Always refresh the dialog's source image so the inline adjustment
+        # sliders can reuse its brightness/contrast pipeline (which includes
+        # 16-bit grayscale handling).
+        self.brightness_contrast_dialog.update_image(
+            utils.img_data_to_pil(self.image_data)
+        )
+        if brightness is not None:
+            self.brightness_contrast_dialog.slider_brightness.setValue(
+                brightness
             )
-            if brightness is not None:
-                self.brightness_contrast_dialog.slider_brightness.setValue(
-                    brightness
-                )
-            if contrast is not None:
-                self.brightness_contrast_dialog.slider_contrast.setValue(
-                    contrast
-                )
+        if contrast is not None:
+            self.brightness_contrast_dialog.slider_contrast.setValue(contrast)
+        if brightness is not None or contrast is not None:
             self.brightness_contrast_dialog.on_new_value()
+        # Sync the inline adjustment sliders (50 is the neutral value).
+        self.canvas_adjustment.set_brightness_contrast(
+            brightness if brightness is not None else 50,
+            contrast if contrast is not None else 50,
+        )
 
         self.paint_canvas()
         self.add_recent_file(self.filename)
@@ -5896,6 +5967,10 @@ class LabelingWidget(LabelDialog):
         self.canvas.setFocus()
         self._sync_annotation_checked_state()
         self.update_thumbnail_display()
+
+        # Reveal the adjustment panel now that an image is loaded.
+        self.canvas_adjustment.show()
+        self._position_canvas_adjustment()
 
         if self.compare_view_manager.is_active():
             self.compare_view_manager.load_compare_for_file(self.filename)
@@ -5921,6 +5996,7 @@ class LabelingWidget(LabelDialog):
         ):
             self.adjust_scale()
         self.update_thumbnail_pixmap()
+        self._position_canvas_adjustment()
 
     def paint_canvas(self):
         if self.image.isNull():

--- a/anylabeling/views/labeling/widgets/__init__.py
+++ b/anylabeling/views/labeling/widgets/__init__.py
@@ -4,6 +4,7 @@ from .about_dialog import AboutDialog
 from .auto_labeling import AutoLabelingWidget
 from .brightness_contrast_dialog import BrightnessContrastDialog
 from .canvas import Canvas
+from .canvas_adjustment import CanvasAdjustmentWidget
 from .compare_view import CompareViewManager, CompareViewSlider
 from .chatbot_dialog import ChatbotDialog
 from .classifier_dialog import ClassifierDialog

--- a/anylabeling/views/labeling/widgets/canvas.py
+++ b/anylabeling/views/labeling/widgets/canvas.py
@@ -228,6 +228,11 @@ class Canvas(
         # Set mask opacity options.
         self.mask_opacity = self.mask_config.get("opacity", 80)
 
+        # Global opacity multiplier for labels/shapes (1.0 = fully opaque).
+        # Controlled by the canvas adjustment panel's opacity slider, whose
+        # neutral default is 50% (CanvasAdjustmentWidget.OPACITY_DEFAULT).
+        self.shape_opacity = 0.5
+
         self.is_loading = False
         self.loading_text = self.tr("Loading...")
         self.loading_angle = 0
@@ -3561,6 +3566,11 @@ class Canvas(
                 ]
                 p.drawPolygon(arrow_points)
 
+        # Apply the global label/shape opacity to every annotation drawn
+        # below (masks, shapes, degrees, groups, brush overlays). Image text
+        # labels are restored to full opacity before being painted.
+        p.setOpacity(self.shape_opacity)
+
         # Draw shape masks
         if self.show_masks:
             for shape in self.shapes:
@@ -3791,6 +3801,9 @@ class Canvas(
             drawing_shape.fill = True
             drawing_shape._closed = True
             drawing_shape.paint(p)
+
+        # Restore full opacity so labels/scores/attributes stay readable.
+        p.setOpacity(1.0)
 
         # Draw texts
         if self.show_texts:

--- a/anylabeling/views/labeling/widgets/canvas_adjustment.py
+++ b/anylabeling/views/labeling/widgets/canvas_adjustment.py
@@ -1,0 +1,206 @@
+"""A compact panel docked at the bottom-left of the canvas.
+
+It groups three sliders that let the user fine tune how the annotations and the
+underlying image are displayed:
+
+- ``Opacity``    : transparency of the labels/shapes (0-100%, default 50%).
+- ``Brightness`` : brightness of the image, mirroring the Brightness/Contrast
+  dialog (slider 0-150, displayed as a 0.00-3.00 factor, neutral 1.00).
+- ``Contrast``   : contrast of the image, same range/mapping as brightness.
+
+The widget only emits signals; the actual rendering is handled by the owner
+(:class:`LabelingWidget`), which reuses the existing brightness/contrast
+pipeline so that 16-bit grayscale images keep working.
+"""
+
+from PyQt6 import QtCore, QtWidgets
+from PyQt6.QtCore import Qt
+
+from ..utils.theme import get_theme
+
+
+class CanvasAdjustmentWidget(QtWidgets.QWidget):
+    """Three-slider panel for label opacity, image brightness and contrast."""
+
+    # Emitted when the opacity slider changes. Value is in range 0-100.
+    opacity_changed = QtCore.pyqtSignal(int)
+    # Emitted when brightness or contrast changes. Values are in range 0-150
+    # (same scale as BrightnessContrastDialog; factor = value / 50).
+    brightness_contrast_changed = QtCore.pyqtSignal(int, int)
+
+    SLIDER_WIDTH = 120
+
+    # Opacity: 0-100%, neutral default centred on the bar.
+    OPACITY_MIN = 0
+    OPACITY_MAX = 100
+    OPACITY_DEFAULT = 50
+
+    # Brightness/contrast: identical to BrightnessContrastDialog's sliders so
+    # the values and initial handle position match the menu-driven dialog.
+    BC_MIN = 0
+    BC_MAX = 150
+    BC_DEFAULT = 50  # 50 / 50 == 1.00 (neutral)
+
+    _LABEL_CSS = (
+        "QLabel { color: #333; font-size: 11px; background: transparent; }"
+    )
+    _RESET_CSS = (
+        "QPushButton { background: rgba(120, 120, 120, 60);"
+        " border-radius: 3px; font-size: 11px; color: #333; padding: 0; }"
+        "QPushButton:hover { background: rgba(120, 120, 120, 110); }"
+        "QPushButton:pressed { background: rgba(120, 120, 120, 150); }"
+    )
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("canvas_adjustment")
+        # A bare QWidget ignores stylesheet background/border unless it is
+        # told to paint a styled background; without this the translucent
+        # card behind the sliders never shows.
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+        self.setStyleSheet(self._build_stylesheet())
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.setContentsMargins(10, 8, 10, 8)
+        layout.setSpacing(5)
+
+        self.opacity_slider, self.opacity_value_label = self._build_row(
+            layout,
+            self.tr("Opacity"),
+            self.OPACITY_MIN,
+            self.OPACITY_MAX,
+            self.OPACITY_DEFAULT,
+            display="percent",
+        )
+        self.brightness_slider, self.brightness_value_label = self._build_row(
+            layout,
+            self.tr("Brightness"),
+            self.BC_MIN,
+            self.BC_MAX,
+            self.BC_DEFAULT,
+            display="factor",
+        )
+        self.contrast_slider, self.contrast_value_label = self._build_row(
+            layout,
+            self.tr("Contrast"),
+            self.BC_MIN,
+            self.BC_MAX,
+            self.BC_DEFAULT,
+            display="factor",
+        )
+
+        self.setLayout(layout)
+        self.adjustSize()
+
+        self.opacity_slider.valueChanged.connect(self._on_opacity_changed)
+        self.brightness_slider.valueChanged.connect(self._on_bc_changed)
+        self.contrast_slider.valueChanged.connect(self._on_bc_changed)
+
+    def _build_stylesheet(self):
+        """Translucent white card with theme-blue sliders."""
+        primary = get_theme().get("primary", "#0071e3")
+        return f"""
+        #canvas_adjustment {{
+            background: rgba(255, 255, 255, 220);
+            border: none;
+            border-radius: 6px;
+        }}
+        #canvas_adjustment QSlider::groove:horizontal {{
+            height: 4px;
+            background: rgba(0, 0, 0, 55);
+            border-radius: 2px;
+        }}
+        #canvas_adjustment QSlider::handle:horizontal {{
+            background: {primary};
+            border: none;
+            width: 14px;
+            height: 14px;
+            margin: -5px 0;
+            border-radius: 7px;
+        }}
+        #canvas_adjustment QSlider::sub-page:horizontal {{
+            background: {primary};
+            border-radius: 2px;
+        }}
+        """
+
+    def _build_row(
+        self, layout, title, minimum, maximum, default, display="percent"
+    ):
+        """Create one labelled slider row and append it to ``layout``."""
+        row = QtWidgets.QHBoxLayout()
+        row.setContentsMargins(0, 0, 0, 0)
+        row.setSpacing(4)
+
+        name_label = QtWidgets.QLabel(title)
+        name_label.setFixedWidth(64)
+        name_label.setStyleSheet(self._LABEL_CSS)
+
+        slider = QtWidgets.QSlider(Qt.Orientation.Horizontal)
+        slider.setRange(minimum, maximum)
+        slider.setValue(default)
+        slider.setFixedWidth(self.SLIDER_WIDTH)
+        slider.setTracking(True)
+        slider.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+
+        value_label = QtWidgets.QLabel()
+        value_label.setProperty("display", display)
+        value_label.setFixedWidth(36)
+        value_label.setAlignment(
+            Qt.AlignmentFlag.AlignRight | Qt.AlignmentFlag.AlignVCenter
+        )
+        value_label.setStyleSheet(self._LABEL_CSS)
+        self._set_value_text(value_label, default)
+
+        reset_btn = QtWidgets.QPushButton("↺")
+        reset_btn.setFixedSize(22, 20)
+        reset_btn.setStyleSheet(self._RESET_CSS)
+        reset_btn.setToolTip(self.tr("Reset to default"))
+        reset_btn.setFocusPolicy(Qt.FocusPolicy.NoFocus)
+        reset_btn.clicked.connect(
+            lambda _=False, s=slider: s.setValue(default)
+        )
+
+        row.addWidget(name_label)
+        row.addWidget(slider)
+        row.addWidget(value_label)
+        row.addWidget(reset_btn)
+        layout.addLayout(row)
+        return slider, value_label
+
+    @staticmethod
+    def _set_value_text(label, value):
+        """Format the value for display based on the label's display mode."""
+        if label.property("display") == "factor":
+            label.setText(f"{value / 50:.2f}")
+        else:
+            label.setText(f"{value}%")
+
+    def _on_opacity_changed(self, value):
+        self._set_value_text(self.opacity_value_label, value)
+        self.opacity_changed.emit(value)
+
+    def _on_bc_changed(self, _=None):
+        brightness = self.brightness_slider.value()
+        contrast = self.contrast_slider.value()
+        self._set_value_text(self.brightness_value_label, brightness)
+        self._set_value_text(self.contrast_value_label, contrast)
+        self.brightness_contrast_changed.emit(brightness, contrast)
+
+    def set_opacity(self, value):
+        """Set the opacity slider without emitting ``opacity_changed``."""
+        self.opacity_slider.blockSignals(True)
+        self.opacity_slider.setValue(value)
+        self.opacity_slider.blockSignals(False)
+        self._set_value_text(self.opacity_value_label, value)
+
+    def set_brightness_contrast(self, brightness, contrast):
+        """Set the brightness/contrast sliders without emitting signals."""
+        for slider, value, label in (
+            (self.brightness_slider, brightness, self.brightness_value_label),
+            (self.contrast_slider, contrast, self.contrast_value_label),
+        ):
+            slider.blockSignals(True)
+            slider.setValue(value)
+            slider.blockSignals(False)
+            self._set_value_text(label, value)


### PR DESCRIPTION
## Summary

Adds a compact **adjustment panel docked at the bottom-left of the canvas** that groups three sliders for quickly tuning how annotations and the underlying image are displayed — without leaving the canvas or opening a dialog:

| Slider | Range | Default | Effect |
|---|---|---|---|
| **Opacity** | 0–100% | 50% | Global transparency of all labels/shapes |
| **Brightness** | 0.00–3.00 | 1.00 | Image brightness |
| **Contrast** | 0.00–3.00 | 1.00 | Image contrast |

## Motivation

Adjusting label opacity and image brightness/contrast is a frequent need while labeling (e.g. dense scenes, low-contrast medical/X-ray images). Today brightness/contrast lives behind a modal dialog and there is no quick way to fade labels to inspect the pixels underneath. This puts all three controls one drag away, always visible while an image is open.

## What's changed

- **New widget** `CanvasAdjustmentWidget` (`widgets/canvas_adjustment.py`): three labeled slider rows with a live value readout and a per-row reset button, wrapped in a translucent white card. Sliders use the theme's primary color.
- **Canvas** (`widgets/canvas.py`): new `Canvas.shape_opacity` multiplier applied in `paintEvent` around the annotation drawing (masks, shapes, degrees, groups, brush overlays). Opacity is restored to `1.0` before text is drawn, so **labels/scores stay fully readable** at any opacity.
- **LabelingWidget** (`label_widget.py`): instantiates and positions the panel over the canvas viewport (bottom-left, tracked on resize), wires the signals, reveals it on image load and hides it on close.

## Design notes

- **Brightness/Contrast reuse the existing `BrightnessContrastDialog` pipeline** (same `0–150` slider scale → `value / 50` factor). This means **16-bit grayscale handling is preserved**, per-file values persist via `brightness_contrast_values`, and the inline sliders stay in sync with the menu-driven dialog.
- **Non-destructive by default**: opacity simply multiplies the existing painter opacity, so rendering is unchanged unless the user moves a slider.
- No new runtime dependencies; no config/schema changes required.

## Screenshots

<img width="320" height="240" alt="Video Project 8" src="https://github.com/user-attachments/assets/1adb7b1f-e172-49f8-8186-627b0317bf24" />


## Testing

- New widget covered by unit checks (ranges, defaults, value formatting, signal emission, programmatic setters).
- Canvas `paintEvent` smoke-tested across opacity values.
- Headless integration check on a real `MainWindow`/`LabelingWidget`: panel hidden before load → shown after load → hidden on close; opacity drives `shape_opacity`; brightness/contrast flow through the dialog pipeline and persist.
- Existing canvas / label-widget / brightness-contrast test suites pass; `black` (line-length 79) and `flake8` clean on the changed files.

---
- [x] I have read and agree to the CLA.
