### PR TITLE
feat: auto-assign incremental group_id when using digit shortcuts

### DIFF
--- a/anylabeling/views/labeling/label_widget.py
+++ b/anylabeling/views/labeling/label_widget.py
@@ -5214,8 +5214,7 @@ class LabelingWidget(LabelDialog):
             if self.digit_to_label is not None:
                 text = self.digit_to_label
                 self.digit_to_label = None
-                if last_gid is not None:
-                    group_id = last_gid
+                group_id = self._get_next_gid(text, self.canvas.create_mode)
             elif self._config["auto_use_last_label"] and last_label:
                 text = last_label
                 if last_gid is not None:
@@ -6881,6 +6880,33 @@ class LabelingWidget(LabelDialog):
             ):
                 return shape.group_id
         return None
+
+    def _get_next_gid(self, label: str, shape_type: str) -> int:
+        """Find the next available group_id for a given label+type combination.
+
+        Scans all existing shapes in the label list and returns the maximum
+        group_id for shapes matching *label* and *shape_type*, plus one.
+
+        Args:
+            label (str): The label to match (e.g. "person_box").
+            shape_type (str): The shape type to match (e.g. "rectangle",
+                "point").
+
+        Returns:
+            int: The next sequential group_id (max existing + 1), or 1 if
+            no matching shapes exist yet.
+        """
+        max_gid = 0
+        for item in self.label_list:
+            shape = item.data(Qt.ItemDataRole.UserRole)
+            if (
+                shape.group_id is not None
+                and isinstance(shape.group_id, int)
+                and shape.label == label
+                and shape.shape_type == shape_type
+            ):
+                max_gid = max(max_gid, shape.group_id)
+        return max_gid + 1
 
     def set_cache_auto_label(self):
         self.auto_labeling_widget.on_cache_auto_label_changed(


### PR DESCRIPTION

**Problem**

When using Digit Shortcuts (1-9 keys) to quickly draw shapes in MOT or
pose annotation workflows, every new shape's `group_id` is left empty
(`null`). Users then have to manually open the Group ID Manager to
assign a sequential `group_id` to each shape — a repetitive step that
breaks the annotation flow.

**Solution**

After drawing a shape via digit shortcut, the code now automatically
calculates the next available `group_id` scoped by the shape's `label`
+ `shape_type` combination and assigns it to the new shape — no manual
intervention needed.

For example, with Digit 1 → rectangle (`person_box`) and Digit 2 →
point (`person_kp`):

| label | type | group_id |
|-------|------|----------|
| person_box | rectangle | 1 |
| person_kp | point | 1 |
| person_box | rectangle | 2 |
| person_kp | point | 2 |

Pressing **1** to draw a new bbox → group_id becomes **3**
Pressing **2** to draw the matching point → group_id also becomes **3**

**Changes**

- Added `_get_next_gid(label, shape_type)` helper — scans existing
  shapes by label + shape_type, returns max group_id + 1.
- In `new_shape()`, replaced the old `last_gid` reuse logic in the
  digit shortcut branch with a call to `_get_next_gid()`.

**Testing**

- App starts without errors
- Digit-shortcut-created shapes now carry sequential group_ids per
  label+type combination
- Normal annotation flow (toolbar buttons, label dialog,
  auto-labeling) — completely unaffected
- Existing MOT/polygon/rectangle workflows that don't use digit
  shortcuts — no behavior change
