### PR TITLE
Add prompt-free Segment Everything (AutoMaskGenerator) for SAM2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,5 +182,3 @@ pnnx*
 
 # calibration image
 calibration_*.npy
-.superpowers/
-

--- a/.gitignore
+++ b/.gitignore
@@ -182,3 +182,5 @@ pnnx*
 
 # calibration image
 calibration_*.npy
+.superpowers/
+

--- a/anylabeling/services/auto_labeling/__base__/amg.py
+++ b/anylabeling/services/auto_labeling/__base__/amg.py
@@ -57,25 +57,42 @@ def generate(
     stability_score_offset=1.0,
     box_nms_thresh=0.7,
     mask_threshold=0.0,
+    points_per_chunk=256,
+    should_stop=None,
 ):
     """Generate deduped low-resolution boolean masks for a whole image.
 
     decode_batch(points_xy[K,2]) -> (logits[K,h,w] float, ious[K] float).
+    The grid is processed in chunks of `points_per_chunk` points so peak memory
+    stays bounded regardless of `points_per_side`; each chunk is reduced to kept
+    boolean masks before the next chunk is decoded. If `should_stop` is provided
+    and returns True, generation aborts and returns an empty list.
     """
     height, width = image_hw
     grid = build_point_grid(points_per_side, height, width)
-    logits, ious = decode_batch(grid)
-    logits = np.asarray(logits, dtype=np.float32)
-    ious = np.asarray(ious, dtype=np.float32)
 
-    stability = _stability_score(logits, mask_threshold, stability_score_offset)
-    keep_mask = (ious >= pred_iou_thresh) & (stability >= stability_score_thresh)
-    if not np.any(keep_mask):
+    kept_masks = []
+    kept_scores = []
+    for start in range(0, len(grid), points_per_chunk):
+        if should_stop is not None and should_stop():
+            return []
+        chunk = grid[start:start + points_per_chunk]
+        logits, ious = decode_batch(chunk)
+        logits = np.asarray(logits, dtype=np.float32)
+        ious = np.asarray(ious, dtype=np.float32)
+
+        stability = _stability_score(
+            logits, mask_threshold, stability_score_offset
+        )
+        keep = (ious >= pred_iou_thresh) & (
+            stability >= stability_score_thresh
+        )
+        for i in np.nonzero(keep)[0]:
+            kept_masks.append(logits[i] > mask_threshold)
+            kept_scores.append(float(ious[i]))
+
+    if not kept_masks:
         return []
 
-    logits = logits[keep_mask]
-    ious = ious[keep_mask]
-    bin_masks = [logits[i] > mask_threshold for i in range(len(logits))]
-
-    kept = _nms(bin_masks, ious, box_nms_thresh)
-    return [bin_masks[i] for i in kept]
+    kept_idx = _nms(kept_masks, np.asarray(kept_scores), box_nms_thresh)
+    return [kept_masks[i] for i in kept_idx]

--- a/anylabeling/services/auto_labeling/__base__/amg.py
+++ b/anylabeling/services/auto_labeling/__base__/amg.py
@@ -1,0 +1,81 @@
+"""Prompt-free AutomaticMaskGenerator core for SAM-family ONNX models.
+
+Framework-agnostic: it takes a `decode_batch` callable and returns
+low-resolution boolean masks. No Qt, no onnxruntime, no SAM-specific imports.
+"""
+import numpy as np
+
+
+def build_point_grid(points_per_side, height, width):
+    """Return an (N, 2) float32 array of (x, y) pixel coords on a regular grid."""
+    frac = (np.arange(points_per_side) + 0.5) / points_per_side
+    xs = frac * width
+    ys = frac * height
+    grid_x, grid_y = np.meshgrid(xs, ys)
+    grid = np.stack([grid_x.ravel(), grid_y.ravel()], axis=-1)
+    return grid.astype(np.float32)
+
+
+def _stability_score(logits, mask_threshold, offset):
+    """IoU between masks thresholded at (t + offset) and (t - offset). (K,) array."""
+    high = logits > (mask_threshold + offset)
+    low = logits > (mask_threshold - offset)
+    inter = np.logical_and(high, low).sum(axis=(-2, -1)).astype(np.float64)
+    union = np.logical_or(high, low).sum(axis=(-2, -1)).astype(np.float64)
+    return np.where(union > 0, inter / np.maximum(union, 1.0), 0.0)
+
+
+def _mask_iou(a, b):
+    inter = np.logical_and(a, b).sum()
+    union = np.logical_or(a, b).sum()
+    return float(inter) / float(union) if union > 0 else 0.0
+
+
+def _nms(masks, scores, iou_thresh):
+    """Greedy mask-IoU NMS. `masks` list of bool arrays, `scores` (N,). Returns kept indices."""
+    order = list(np.argsort(scores)[::-1])
+    suppressed = [False] * len(masks)
+    keep = []
+    for idx_pos, i in enumerate(order):
+        if suppressed[i]:
+            continue
+        keep.append(i)
+        for j in order[idx_pos + 1:]:
+            if suppressed[j]:
+                continue
+            if _mask_iou(masks[i], masks[j]) > iou_thresh:
+                suppressed[j] = True
+    return keep
+
+
+def generate(
+    decode_batch,
+    image_hw,
+    points_per_side=32,
+    pred_iou_thresh=0.88,
+    stability_score_thresh=0.95,
+    stability_score_offset=1.0,
+    box_nms_thresh=0.7,
+    mask_threshold=0.0,
+):
+    """Generate deduped low-resolution boolean masks for a whole image.
+
+    decode_batch(points_xy[K,2]) -> (logits[K,h,w] float, ious[K] float).
+    """
+    height, width = image_hw
+    grid = build_point_grid(points_per_side, height, width)
+    logits, ious = decode_batch(grid)
+    logits = np.asarray(logits, dtype=np.float32)
+    ious = np.asarray(ious, dtype=np.float32)
+
+    stability = _stability_score(logits, mask_threshold, stability_score_offset)
+    keep_mask = (ious >= pred_iou_thresh) & (stability >= stability_score_thresh)
+    if not np.any(keep_mask):
+        return []
+
+    logits = logits[keep_mask]
+    ious = ious[keep_mask]
+    bin_masks = [logits[i] > mask_threshold for i in range(len(logits))]
+
+    kept = _nms(bin_masks, ious, box_nms_thresh)
+    return [bin_masks[i] for i in kept]

--- a/anylabeling/services/auto_labeling/__base__/mask_shapes.py
+++ b/anylabeling/services/auto_labeling/__base__/mask_shapes.py
@@ -31,7 +31,8 @@ def masks_to_shapes(
             contour, epsilon * cv2.arcLength(contour, True), True
         )
         points = approx.reshape(-1, 2)
-        if len(points) < 3:
+        min_points = 2 if output_mode == "contour" else 3
+        if len(points) < min_points:
             continue
 
         shape = Shape(flags={})

--- a/anylabeling/services/auto_labeling/__base__/mask_shapes.py
+++ b/anylabeling/services/auto_labeling/__base__/mask_shapes.py
@@ -1,0 +1,51 @@
+"""Convert a binary mask into AnyLabeling Shape objects (polygon or contour)."""
+import cv2
+import numpy as np
+from PyQt6 import QtCore
+
+from anylabeling.views.labeling.shape import Shape
+
+
+def masks_to_shapes(
+    mask,
+    output_mode,
+    epsilon=0.001,
+    min_area=0,
+    label="AUTOLABEL_OBJECT",
+):
+    """Return a list of Shape objects for every external contour of `mask`.
+
+    output_mode == "contour" -> open linestrip; anything else -> closed polygon.
+    Contours with area < min_area are dropped.
+    """
+    binary = (mask > 0).astype(np.uint8) * 255
+    contours, _ = cv2.findContours(
+        binary, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_NONE
+    )
+
+    shapes = []
+    for contour in contours:
+        if cv2.contourArea(contour) < min_area:
+            continue
+        approx = cv2.approxPolyDP(
+            contour, epsilon * cv2.arcLength(contour, True), True
+        )
+        points = approx.reshape(-1, 2)
+        if len(points) < 3:
+            continue
+
+        shape = Shape(flags={})
+        for x, y in points:
+            shape.add_point(QtCore.QPointF(int(x), int(y)))
+        if output_mode == "contour":
+            shape.shape_type = "linestrip"
+            shape.closed = False
+        else:
+            shape.shape_type = "polygon"
+            shape.closed = True
+        shape.fill_color = "#000000"
+        shape.line_color = "#000000"
+        shape.label = label
+        shape.selected = False
+        shapes.append(shape)
+    return shapes

--- a/anylabeling/services/auto_labeling/__base__/sam2.py
+++ b/anylabeling/services/auto_labeling/__base__/sam2.py
@@ -6,6 +6,12 @@ import onnxruntime as ort
 from numpy import ndarray
 
 
+def iter_point_batches(points, points_per_batch):
+    """Yield consecutive slices of `points` of length <= points_per_batch."""
+    for start in range(0, len(points), points_per_batch):
+        yield points[start : start + points_per_batch]
+
+
 class SegmentAnything2ONNX:
     """Segmentation model using Segment Anything 2 (SAM2)"""
 
@@ -57,6 +63,44 @@ class SegmentAnything2ONNX:
         )
 
         return masks
+
+    def predict_masks_batch(self, embedding, points_xy, points_per_batch=64):
+        """Decode a grid of single foreground points.
+
+        points_xy: (K, 2) pixel coords. Returns (logits[K, h, w], ious[K]) where
+        each entry is the highest-scoring low-resolution mask for that point.
+        """
+        image_embedding = embedding["image_embedding"]
+        high_res_feats_0 = embedding["high_res_feats_0"]
+        high_res_feats_1 = embedding["high_res_feats_1"]
+        original_size = embedding["original_size"]
+        self.decoder.set_image_size(original_size)
+
+        all_logits = []
+        all_scores = []
+        for batch in iter_point_batches(points_xy, points_per_batch):
+            coords = [np.asarray(p, dtype=np.float32).reshape(1, 2) for p in batch]
+            labels = [np.array([1], dtype=np.float32) for _ in batch]
+            masks, scores = self.decoder.predict_batch(
+                image_embedding,
+                high_res_feats_0,
+                high_res_feats_1,
+                coords,
+                labels,
+            )
+            scores = np.asarray(scores)
+            masks = np.asarray(masks)
+            if scores.ndim == 1:  # single-mask decoders: (B,) -> (B, 1)
+                scores = scores[:, None]
+                masks = masks[:, None]
+            best = np.argmax(scores, axis=1)
+            rows = np.arange(masks.shape[0])
+            all_logits.append(masks[rows, best])
+            all_scores.append(scores[rows, best])
+        return (
+            np.concatenate(all_logits, axis=0),
+            np.concatenate(all_scores, axis=0),
+        )
 
     def transform_masks(self, masks, original_size, transform_matrix):
         """Transform the masks back to the original image size."""
@@ -237,6 +281,29 @@ class SAM2ImageDecoder:
         outputs = self.forward_decoder(inputs)
 
         return self.process_output(outputs)
+
+    def predict_batch(
+        self,
+        image_embed,
+        high_res_feats_0,
+        high_res_feats_1,
+        point_coords,
+        point_labels,
+    ):
+        """Run the decoder on a batch of prompts and return raw masks + scores.
+
+        Returns (masks[B, num_masks, h, w], scores[B, num_masks]) without
+        selecting the best mask or resizing to the original image size.
+        """
+        inputs = self.prepare_inputs(
+            image_embed,
+            high_res_feats_0,
+            high_res_feats_1,
+            point_coords,
+            point_labels,
+        )
+        outputs = self.forward_decoder(inputs)
+        return outputs[0], outputs[1]
 
     def prepare_inputs(
         self,

--- a/anylabeling/services/auto_labeling/segment_anything_2.py
+++ b/anylabeling/services/auto_labeling/segment_anything_2.py
@@ -268,6 +268,23 @@ class SegmentAnything2(Model):
             shape.label = "AUTOLABEL_OBJECT"
             shape.selected = False
             shapes.append(shape)
+        elif self.output_mode == "contour":
+            for approx in approx_contours:
+                points = approx.reshape(-1, 2).tolist()
+                if len(points) < 2:
+                    continue
+                shape = Shape(flags={})
+                for point in points:
+                    shape.add_point(
+                        QtCore.QPointF(int(point[0]), int(point[1]))
+                    )
+                shape.shape_type = "linestrip"
+                shape.closed = False
+                shape.fill_color = "#000000"
+                shape.line_color = "#000000"
+                shape.label = "AUTOLABEL_OBJECT"
+                shape.selected = False
+                shapes.append(shape)
 
         return shapes
 

--- a/anylabeling/services/auto_labeling/segment_anything_2.py
+++ b/anylabeling/services/auto_labeling/segment_anything_2.py
@@ -22,6 +22,8 @@ from .model import Model
 from .types import AutoLabelingResult
 from .__base__.clip import ChineseClipONNX
 from .__base__.sam2 import SegmentAnything2ONNX
+from .__base__ import amg
+from .__base__.mask_shapes import masks_to_shapes
 
 
 class SegmentAnything2(Model):
@@ -47,11 +49,15 @@ class SegmentAnything2(Model):
             "button_cropping",
             "mask_fineness_slider",
             "mask_fineness_value_label",
+            "button_segment_everything",
+            "input_points_per_side",
+            "input_min_area",
         ]
         output_modes = {
             "polygon": QCoreApplication.translate("Model", "Polygon"),
             "rectangle": QCoreApplication.translate("Model", "Rectangle"),
             "rotation": QCoreApplication.translate("Model", "Rotation"),
+            "contour": QCoreApplication.translate("Model", "Contour"),
         }
         default_output_mode = "polygon"
 
@@ -265,12 +271,66 @@ class SegmentAnything2(Model):
 
         return shapes
 
+    def _predict_auto_grid(self, image, filename=None) -> AutoLabelingResult:
+        """Prompt-free 'segment everything' via AutomaticMaskGenerator."""
+        params = self.marks[0]
+        points_per_side = int(params.get("points_per_side", 32))
+        min_area = int(params.get("min_area", 100))
+
+        cv_image = qt_img_to_rgb_cv_img(image, filename)
+        original_height, original_width = cv_image.shape[:2]
+
+        try:
+            cached = self.image_embedding_cache.get(filename)
+            if cached is not None:
+                image_embedding = cached
+            else:
+                if self.stop_inference:
+                    return AutoLabelingResult([], replace=False)
+                image_embedding = self.model.encode(cv_image)
+                self.image_embedding_cache.put(filename, image_embedding)
+
+            def decode_batch(points_xy):
+                return self.model.predict_masks_batch(image_embedding, points_xy)
+
+            low_res_masks = amg.generate(
+                decode_batch,
+                (original_height, original_width),
+                points_per_side=points_per_side,
+            )
+
+            shapes = []
+            for low in low_res_masks:
+                full = cv2.resize(
+                    low.astype(np.uint8),
+                    (original_width, original_height),
+                    interpolation=cv2.INTER_NEAREST,
+                )
+                shapes.extend(
+                    masks_to_shapes(
+                        full,
+                        self.output_mode,
+                        epsilon=self.epsilon,
+                        min_area=min_area,
+                    )
+                )
+        except Exception as e:  # noqa
+            logger.warning("Could not run segment-everything inference")
+            logger.warning(e)
+            traceback.print_exc()
+            return AutoLabelingResult([], replace=False)
+
+        return AutoLabelingResult(shapes, replace=False)
+
     def predict_shapes(self, image, filename=None) -> AutoLabelingResult:
         """
         Predict shapes from image
         """
         if image is None or not self.marks:
             return AutoLabelingResult([], replace=False)
+
+        if self.marks[0].get("type") == "auto_grid":
+            return self._predict_auto_grid(image, filename)
 
         shapes = []
         cv_image = qt_img_to_rgb_cv_img(image, filename)

--- a/anylabeling/services/auto_labeling/segment_anything_2.py
+++ b/anylabeling/services/auto_labeling/segment_anything_2.py
@@ -314,6 +314,7 @@ class SegmentAnything2(Model):
                 decode_batch,
                 (original_height, original_width),
                 points_per_side=points_per_side,
+                should_stop=lambda: self.stop_inference,
             )
 
             shapes = []

--- a/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
+++ b/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
@@ -425,6 +425,7 @@ class AutoLabelingWidget(QWidget):
         # --- Configuration for: input_points_per_side ---
         self.input_points_per_side.setRange(4, 64)
         self.input_points_per_side.setValue(32)
+        self.input_points_per_side.setPrefix(self.tr("Density: "))
         self.input_points_per_side.setToolTip(
             self.tr("Grid density (points per side)")
         )
@@ -432,6 +433,7 @@ class AutoLabelingWidget(QWidget):
         # --- Configuration for: input_min_area ---
         self.input_min_area.setRange(0, 1000000)
         self.input_min_area.setValue(100)
+        self.input_min_area.setPrefix(self.tr("Min area: "))
         self.input_min_area.setToolTip(self.tr("Minimum region area in pixels"))
 
         # ===================================

--- a/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
+++ b/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
@@ -412,6 +412,28 @@ class AutoLabelingWidget(QWidget):
         """)
         self.on_mask_fineness_changed(self.mask_fineness_slider.value())
 
+        # --- Configuration for: button_segment_everything ---
+        self.button_segment_everything.setText(self.tr("Segment Everything"))
+        self.button_segment_everything.setStyleSheet(get_normal_button_style())
+        self.button_segment_everything.clicked.connect(
+            self.on_segment_everything_clicked
+        )
+        self.button_segment_everything.setToolTip(
+            self.tr("Automatically segment the whole image (no prompts)")
+        )
+
+        # --- Configuration for: input_points_per_side ---
+        self.input_points_per_side.setRange(4, 64)
+        self.input_points_per_side.setValue(32)
+        self.input_points_per_side.setToolTip(
+            self.tr("Grid density (points per side)")
+        )
+
+        # --- Configuration for: input_min_area ---
+        self.input_min_area.setRange(0, 1000000)
+        self.input_min_area.setValue(100)
+        self.input_min_area.setToolTip(self.tr("Minimum region area in pixels"))
+
         # ===================================
         #  End of Auto labeling buttons
         # ===================================
@@ -882,6 +904,19 @@ class AutoLabelingWidget(QWidget):
                 self.parent.image, self.parent.filename
             )
 
+    def on_segment_everything_clicked(self):
+        """Trigger prompt-free full-image segmentation."""
+        self.model_manager.set_auto_labeling_marks(
+            [
+                {
+                    "type": "auto_grid",
+                    "points_per_side": self.input_points_per_side.value(),
+                    "min_area": self.input_min_area.value(),
+                }
+            ]
+        )
+        self.run_prediction()
+
     def run_vl_prediction(self):
         """Run visual-language prediction"""
         if self.parent.filename is not None and self.edit_text:
@@ -1159,6 +1194,9 @@ class AutoLabelingWidget(QWidget):
             "button_skip_detection",
             "mask_fineness_slider",
             "mask_fineness_value_label",
+            "button_segment_everything",
+            "input_points_per_side",
+            "input_min_area",
         ]
         for widget in widgets:
             getattr(self, widget).hide()

--- a/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.ui
+++ b/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.ui
@@ -415,6 +415,19 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="button_segment_everything">
+       <property name="text">
+        <string>Segment Everything</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="input_points_per_side"/>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="input_min_area"/>
+     </item>
+     <item>
       <widget class="QPushButton" name="button_skip_detection">
        <property name="text">
         <string>Skip Det (Off)</string>

--- a/tests/segment_everything/test_amg.py
+++ b/tests/segment_everything/test_amg.py
@@ -1,0 +1,44 @@
+import numpy as np
+from anylabeling.services.auto_labeling.__base__ import amg
+
+
+def _stub_decode_factory(h=32, w=32):
+    """Two objects at grid-normalized regions A and B in a 32x32 low-res mask.
+    A: rows/cols 4..12 ; B: rows/cols 20..28. A point 'hits' an object if it
+    falls inside that object's pixel box in a 320x320 image."""
+    def decode_batch(points_xy):
+        K = len(points_xy)
+        logits = np.full((K, h, w), -10.0, dtype=np.float32)
+        ious = np.full((K,), 0.5, dtype=np.float32)
+        for k, (x, y) in enumerate(points_xy):
+            if 40 <= x <= 120 and 40 <= y <= 120:
+                logits[k, 4:12, 4:12] = 10.0
+                ious[k] = 0.95
+            elif 200 <= x <= 280 and 200 <= y <= 280:
+                logits[k, 20:28, 20:28] = 10.0
+                ious[k] = 0.95
+        return logits, ious
+    return decode_batch
+
+
+def test_build_point_grid_shape_and_range():
+    grid = amg.build_point_grid(4, 320, 320)
+    assert grid.shape == (16, 2)
+    assert grid[:, 0].min() > 0 and grid[:, 0].max() < 320
+
+
+def test_generate_returns_two_deduped_masks():
+    decode = _stub_decode_factory()
+    masks = amg.generate(decode, (320, 320), points_per_side=32)
+    assert len(masks) == 2
+    for m in masks:
+        assert m.dtype == np.bool_
+        assert m.sum() > 0
+
+
+def test_generate_filters_low_iou_only_background():
+    def decode(points_xy):
+        K = len(points_xy)
+        return np.full((K, 32, 32), -10.0, dtype=np.float32), np.full((K,), 0.5, np.float32)
+    masks = amg.generate(decode, (320, 320), points_per_side=16)
+    assert masks == []

--- a/tests/segment_everything/test_amg.py
+++ b/tests/segment_everything/test_amg.py
@@ -42,3 +42,17 @@ def test_generate_filters_low_iou_only_background():
         return np.full((K, 32, 32), -10.0, dtype=np.float32), np.full((K,), 0.5, np.float32)
     masks = amg.generate(decode, (320, 320), points_per_side=16)
     assert masks == []
+
+
+def test_generate_should_stop_returns_empty():
+    decode = _stub_decode_factory()
+    masks = amg.generate(decode, (320, 320), points_per_side=32,
+                         should_stop=lambda: True)
+    assert masks == []
+
+
+def test_generate_chunking_matches_single_pass():
+    decode = _stub_decode_factory()
+    small_chunks = amg.generate(decode, (320, 320), points_per_side=32,
+                               points_per_chunk=4)
+    assert len(small_chunks) == 2  # chunk size must not change the result

--- a/tests/segment_everything/test_mask_shapes.py
+++ b/tests/segment_everything/test_mask_shapes.py
@@ -1,0 +1,32 @@
+import os
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+import numpy as np
+from anylabeling.services.auto_labeling.__base__ import mask_shapes
+
+
+def _square_mask(size=64, lo=16, hi=48):
+    m = np.zeros((size, size), dtype=np.uint8)
+    m[lo:hi, lo:hi] = 255
+    return m
+
+
+def test_polygon_mode_produces_closed_polygon():
+    shapes = mask_shapes.masks_to_shapes(_square_mask(), "polygon", min_area=10)
+    assert len(shapes) == 1
+    assert shapes[0].shape_type == "polygon"
+    assert shapes[0].closed is True
+    assert len(shapes[0].points) >= 4
+
+
+def test_contour_mode_produces_open_linestrip():
+    shapes = mask_shapes.masks_to_shapes(_square_mask(), "contour", min_area=10)
+    assert len(shapes) == 1
+    assert shapes[0].shape_type == "linestrip"
+    assert shapes[0].closed is False
+
+
+def test_min_area_filters_small_regions():
+    m = np.zeros((64, 64), dtype=np.uint8)
+    m[10:13, 10:13] = 255  # 9-px region
+    shapes = mask_shapes.masks_to_shapes(m, "polygon", min_area=100)
+    assert shapes == []

--- a/tests/segment_everything/test_point_batches.py
+++ b/tests/segment_everything/test_point_batches.py
@@ -1,0 +1,16 @@
+import numpy as np
+from anylabeling.services.auto_labeling.__base__.sam2 import iter_point_batches
+
+
+def test_iter_point_batches_splits_evenly():
+    pts = np.arange(20).reshape(10, 2)
+    batches = list(iter_point_batches(pts, 4))
+    assert [len(b) for b in batches] == [4, 4, 2]
+    assert np.array_equal(np.concatenate(batches, axis=0), pts)
+
+
+def test_iter_point_batches_single_batch():
+    pts = np.arange(6).reshape(3, 2)
+    batches = list(iter_point_batches(pts, 64))
+    assert len(batches) == 1
+    assert np.array_equal(batches[0], pts)


### PR DESCRIPTION
﻿# Add prompt-free "Segment Everything" (AutoMaskGenerator) for SAM2

Closes #1091.

## Try it out (before it's merged)

Run this branch directly with [uv](https://docs.astral.sh/uv/) — no clone, ephemeral environment:

```bash
uvx --from "x-anylabeling-cvhub[cpu] @ git+https://github.com/CEA-MetroCarac/X-AnyLabeling.git@feat/segment-everything" xanylabeling
```

For GPU (CUDA 12.x) swap `[cpu]` → `[gpu]`. Requires Python ≥ 3.11 (uv fetches one automatically). Then: load an image → pick a **Segment Anything 2** model (weights auto-download on first use) → click **Segment Everything**.

## What
Adds a prompt-free **Segment Everything** mode to the SAM2 auto-labeling model: instead of clicking points/boxes, one button segments the whole image at once (SAM's AutomaticMaskGenerator), producing editable shapes. Output can be **filled polygons** (labeling) or **open contour linestrips** (measurement/metrology), selectable via the existing output-mode dropdown.

## Why
Issue #1091 asked for an AutoMaskGenerator ("segment everything") equivalent — the existing SAM/SAM2 models only support interactive point/box prompting and return an empty result when there are no marks. This fills that gap.

## How
- **Reuses the existing ONNX encoder/decoder** — no new model, no new dependency, no torch. A regular grid of foreground points is decoded (batched, in low resolution) through the current SAM2 decoder; masks are filtered by predicted-IoU + stability score, deduped with IoU NMS, upscaled, and converted to shapes.
- **Non-invasive trigger:** the button sets a synthetic `{"type": "auto_grid", ...}` mark and reuses the existing `run_prediction()` path, so the base `predict_shapes(image, filename)` signature is unchanged.
- **Bounded memory:** the point grid is processed in chunks (default 256 points/chunk), so peak memory stays flat regardless of grid density; the run is cancellable via the model's `stop_inference` flag.

### New / changed
- `services/auto_labeling/__base__/amg.py` (new) — pure-numpy AutomaticMaskGenerator core (grid, stability score, mask-IoU NMS, chunked generation).
- `services/auto_labeling/__base__/mask_shapes.py` (new) — mask → polygon / linestrip conversion.
- `services/auto_labeling/__base__/sam2.py` — additive batched low-res decode (`predict_masks_batch`, `SAM2ImageDecoder.predict_batch`, `iter_point_batches`).
- `services/auto_labeling/segment_anything_2.py` — `auto_grid` routing, `contour` output mode, `_predict_auto_grid`.
- `views/labeling/widgets/auto_labeling/auto_labeling.{ui,py}` — "Segment Everything" button + **Density** and **Min area** spinboxes.

### UI controls
- **Segment Everything** button — runs it, no prompts needed.
- **Density** (points per side, 4–64, default 32) — grid resolution.
- **Min area** (px, default 100) — drops tiny regions.
- **Output** (existing dropdown) — Polygon (filled) or Contour (open linestrip).

## Screenshots
One click, no prompts — the whole image segmented into editable shapes. Same image, the two output modes:

| Polygons (labeling) | Contours (metrology) |
|---|---|
| <img width="1235" height="659" alt="segment-everything-polygons" src="https://github.com/user-attachments/assets/51e3f553-2a5b-46bb-90ac-362915ecc698" /> | <img width="1235" height="659" alt="segment-everything-contours" src="https://github.com/user-attachments/assets/a81e6565-a30d-4475-9493-dc2ea11bec2a" /> |

## Testing
- New unit tests under `tests/segment_everything/` (10 tests): AMG core (grid, filtering, NMS dedup, chunking invariance, cancellation), point batching, and mask→shape conversion (polygon vs contour, min-area). All green.
- The prompted point/box path is unchanged and still works.

## Notes / scope
- Wired for **SAM2** first; the same pattern can extend to the other SAM variants in follow-ups.
- In auto mode, the Rectangle/Rotation output modes fall back to polygons (Segment-Everything emits polygon or contour); the prompted path still supports all modes.
- `box_nms_thresh` is implemented as mask-IoU NMS (named after SAM's upstream parameter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

