### PR TITLE
Add open-vocabulary YOLOE video tracking

### DIFF
--- a/anylabeling/configs/auto_labeling/yoloe_11s_tracktrack.yaml
+++ b/anylabeling/configs/auto_labeling/yoloe_11s_tracktrack.yaml
@@ -1,0 +1,29 @@
+type: yoloe
+name: yoloe_11s_tracktrack-r20260716
+provider: THU
+display_name: YOLOE-11-S-TrackTrack
+model_path: https://github.com/CVHub520/X-AnyLabeling/releases/download/v3.0.0/yoloe-11s-seg.pt
+model_pf_path: https://github.com/CVHub520/X-AnyLabeling/releases/download/v3.0.0/yoloe-11s-seg-pf.pt
+embedding_model_path: https://github.com/CVHub520/X-AnyLabeling/releases/download/v3.0.0/mobileclip_blt.pt
+input_height: 640
+input_width: 640
+iou_threshold: 0.70
+conf_threshold: 0.25
+max_det: 1000
+with_mask: false
+tracker:
+  tracker_type: tracktrack
+  track_high_thresh: 0.5
+  track_low_thresh: 0.1
+  new_track_thresh: 0.6
+  track_buffer: 30
+  match_thresh: 0.7
+  lost_match_thr: 0.0
+  iou_weight: 0.5
+  conf_weight: 0.1
+  angle_weight: 0.05
+  penalty_p: 0.2
+  reduce_step: 0.05
+  tai_thr: 0.55
+  min_track_len: 1
+  gmc_method: sparseOptFlow

--- a/anylabeling/configs/models.yaml
+++ b/anylabeling/configs/models.yaml
@@ -214,6 +214,8 @@
   config_file: ":/yolo12x.yaml"
 - model_name: "yoloe_11s-r20250524"
   config_file: ":/yoloe_11s.yaml"
+- model_name: "yoloe_11s_tracktrack-r20260716"
+  config_file: ":/yoloe_11s_tracktrack.yaml"
 - model_name: "yoloe_v8l-r20250524"
   config_file: ":/yoloe_v8l.yaml"
 - model_name: "yolov5l-r20230520"

--- a/anylabeling/services/auto_labeling/__init__.py
+++ b/anylabeling/services/auto_labeling/__init__.py
@@ -179,6 +179,7 @@ _AUTO_LABELING_API_TOKEN_MODELS = [
 # --- set_auto_labeling_reset_tracker ---
 _AUTO_LABELING_RESET_TRACKER_MODELS = [
     "remote_server",
+    "yoloe",
     "yolov5_det_track",
     "yolov8_det_track",
     "yolov8_obb_track",

--- a/anylabeling/services/auto_labeling/yoloe.py
+++ b/anylabeling/services/auto_labeling/yoloe.py
@@ -1,4 +1,7 @@
 import os
+from argparse import Namespace
+from typing import Any, Optional
+
 import numpy as np
 from PIL import Image
 
@@ -8,7 +11,9 @@ from PyQt6.QtCore import QCoreApplication
 from anylabeling.views.labeling.shape import Shape
 from anylabeling.views.labeling.logger import logger
 from .model import Model
+from .trackers import BOTSORT, BYTETracker, TRACKTRACK
 from .types import AutoLabelingResult
+from .utils import xyxy2xywh
 
 try:
     import torch
@@ -71,6 +76,7 @@ class YOLOE(Model):
             "toggle_preserve_existing_annotations",
             "button_add_rect",
             "button_clear",
+            "button_reset_tracker",
         ]
         output_modes = {
             "rectangle": QCoreApplication.translate("Model", "Rectangle"),
@@ -126,6 +132,7 @@ class YOLOE(Model):
         self.iou_thres = self.config.get("iou_threshold", 0.70)
         self.conf_thres = self.config.get("conf_threshold", 0.25)
         self.replace = True
+        self.tracker = self._build_tracker(self.config.get("tracker"))
 
         self.text_prompt = None
 
@@ -183,8 +190,83 @@ class YOLOE(Model):
         """Toggle preservation of existing annotations"""
         self.replace = not state
 
-    def postprocess(self, results):
-        """Post-process model predictions into shapes"""
+    @staticmethod
+    def _build_tracker(tracker_config: Optional[dict]) -> Optional[Any]:
+        """Build a tracker from an X-AnyLabeling tracker configuration.
+
+        Args:
+            tracker_config (Optional[dict]): Tracker settings using the same
+                schema as the built-in YOLO tracking models.
+
+        Returns:
+            Optional[Any]: An initialized tracker, or ``None`` when tracking
+                is disabled or the tracker type is unsupported.
+        """
+        if not tracker_config:
+            return None
+
+        tracker_args = Namespace(**tracker_config)
+        tracker_type = tracker_args.tracker_type
+        if tracker_type == "bytetrack":
+            return BYTETracker(tracker_args, frame_rate=30)
+        if tracker_type == "botsort":
+            return BOTSORT(tracker_args, frame_rate=30)
+        if tracker_type == "tracktrack":
+            return TRACKTRACK(tracker_args, frame_rate=30)
+
+        logger.error(
+            "Only 'bytetrack', 'botsort' and 'tracktrack' are supported "
+            f"for YOLOE tracking, but got '{tracker_type}'!"
+        )
+        return None
+
+    def _update_tracker(
+        self,
+        bboxes: np.ndarray,
+        scores: np.ndarray,
+        class_ids: np.ndarray,
+        image: Image.Image,
+    ) -> np.ndarray:
+        """Associate open-vocabulary detections across consecutive frames.
+
+        Args:
+            bboxes (np.ndarray): Detection boxes in ``xyxy`` format.
+            scores (np.ndarray): Detection confidence scores.
+            class_ids (np.ndarray): Numeric class identifiers produced by
+                YOLOE for the active vocabulary.
+            image (Image.Image): Current video frame.
+
+        Returns:
+            np.ndarray: Tracker results with columns ``xyxy``, ``track_id``,
+                ``score``, ``class_id`` and ``detection_index``.
+        """
+        if self.tracker is None:
+            return np.empty((0, 8), dtype=np.float32)
+        return self.tracker.update(
+            scores.flatten(),
+            xyxy2xywh(bboxes),
+            class_ids.flatten(),
+            np.asarray(image),
+        )
+
+    def set_auto_labeling_reset_tracker(self) -> None:
+        """Reset all YOLOE track identities and temporal state."""
+        if self.tracker is not None:
+            self.tracker.reset()
+
+    def postprocess(
+        self, results: Any, image: Optional[Image.Image] = None
+    ) -> list[Shape]:
+        """Convert YOLOE predictions to shapes with stable track IDs.
+
+        Args:
+            results (Any): Ultralytics YOLOE prediction results.
+            image (Optional[Image.Image]): Current frame used by the tracker.
+
+        Returns:
+            list[Shape]: Rectangle or polygon annotations. Tracked shapes use
+                ``group_id`` as their persistent object identity.
+        """
         if results is None:
             return []
 
@@ -199,11 +281,33 @@ class YOLOE(Model):
         bboxes = detections.xyxy
         labels = detections["class_name"]
         scores = detections.confidence
+        class_ids = detections.class_id
+        track_ids = np.full(len(bboxes), None, dtype=object)
+
+        if self.tracker is not None and image is not None:
+            tracks = self._update_tracker(bboxes, scores, class_ids, image)
+            if len(tracks) == 0:
+                return []
+
+            detection_indices = tracks[:, 7].astype(int)
+            valid = (detection_indices >= 0) & (
+                detection_indices < len(bboxes)
+            )
+            tracks = tracks[valid]
+            detection_indices = detection_indices[valid]
+            bboxes = tracks[:, :4]
+            track_ids = tracks[:, 4].astype(int)
+            scores = tracks[:, 5]
+            labels = labels[detection_indices]
+            if masks is not None:
+                masks = masks[detection_indices]
         shapes = []
 
         # Generate rectangle shapes
         if self.output_mode == "rectangle":
-            for xyxy, label, score in zip(bboxes, labels, scores):
+            for xyxy, label, score, track_id in zip(
+                bboxes, labels, scores, track_ids
+            ):
                 shape = Shape(flags={})
                 xmin, ymin, xmax, ymax = xyxy
                 shape.add_point(QtCore.QPointF(float(xmin), float(ymin)))
@@ -214,13 +318,22 @@ class YOLOE(Model):
                 shape.closed = True
                 shape.score = float(score)
                 shape.label = str(label)
+                shape.group_id = (
+                    int(track_id) if track_id is not None else None
+                )
                 shape.selected = False
                 shapes.append(shape)
 
         # Generate polygon shapes from masks
-        if self.output_mode == "polygon" or self.with_mask:
-            for mask, label, score in zip(masks, labels, scores):
+        if (
+            self.output_mode == "polygon" or self.with_mask
+        ) and masks is not None:
+            for mask, label, score, track_id in zip(
+                masks, labels, scores, track_ids
+            ):
                 polygons = mask_to_polygons(mask)
+                if not polygons:
+                    continue
                 points = polygons[0].tolist()
                 points.append(points[0])
 
@@ -229,7 +342,11 @@ class YOLOE(Model):
                     shape.add_point(QtCore.QPointF(point[0], point[1]))
                 shape.shape_type = "polygon"
                 shape.closed = True
-                shape.label = label
+                shape.label = str(label)
+                shape.score = float(score)
+                shape.group_id = (
+                    int(track_id) if track_id is not None else None
+                )
                 shape.selected = False
                 shapes.append(shape)
 
@@ -274,6 +391,27 @@ class YOLOE(Model):
         self._prompt_free_model.model.model[-1].conf = self.conf_thres
         return self._prompt_free_model
 
+    @staticmethod
+    def _parse_text_prompt(text_prompt: str) -> list[str]:
+        """Normalize a dot- or comma-separated open-vocabulary prompt.
+
+        Args:
+            text_prompt (str): User-entered class names.
+
+        Returns:
+            list[str]: Non-empty class names in prompt order.
+
+        Raises:
+            ValueError: If no usable class name remains after normalization.
+        """
+        normalized = text_prompt.strip().replace(",", ".")
+        texts = [
+            item.strip() for item in normalized.split(".") if item.strip()
+        ]
+        if not texts:
+            raise ValueError("text_prompt must contain at least one class")
+        return texts
+
     def predict_shapes(self, image, image_path=None, text_prompt=None):
         """Predict shapes from image using different prompting modes"""
 
@@ -313,11 +451,7 @@ class YOLOE(Model):
 
         # Text prompting mode
         elif text_prompt:
-            text_prompt = text_prompt.strip()
-            text_prompt = text_prompt.replace(",", ".")
-            while text_prompt.endswith("."):
-                text_prompt = text_prompt[:-1]
-            texts = [text.strip() for text in text_prompt.split(".")]
+            texts = self._parse_text_prompt(text_prompt)
 
             # Reset text model if prompt changed
             if self.text_prompt is None:
@@ -326,6 +460,7 @@ class YOLOE(Model):
                 if self.text_prompt != texts:
                     self._text_model = None
                     self.text_prompt = texts
+                    self.set_auto_labeling_reset_tracker()
             logger.debug(f"Input texts: {texts}")
 
             model = self._get_text_model(texts)
@@ -350,7 +485,7 @@ class YOLOE(Model):
                 **kwargs,
             )
 
-        shapes = self.postprocess(results)
+        shapes = self.postprocess(results, image=image)
         result = AutoLabelingResult(shapes, replace=self.replace)
         return result
 

--- a/anylabeling/services/auto_labeling/yoloe.py
+++ b/anylabeling/services/auto_labeling/yoloe.py
@@ -76,7 +76,6 @@ class YOLOE(Model):
             "toggle_preserve_existing_annotations",
             "button_add_rect",
             "button_clear",
-            "button_reset_tracker",
         ]
         output_modes = {
             "rectangle": QCoreApplication.translate("Model", "Rectangle"),
@@ -148,6 +147,18 @@ class YOLOE(Model):
             self.texts = list(classes.values())
         else:
             self.texts = self.load_tag_list()
+
+    def get_required_widgets(self) -> list[str]:
+        """Return YOLOE widgets enabled by the active configuration.
+
+        Returns:
+            list[str]: Base YOLOE widgets, with the tracker reset control
+                appended only when a tracker was initialized.
+        """
+        widgets = list(self.Meta.widgets)
+        if self.tracker is not None:
+            widgets.append("button_reset_tracker")
+        return widgets
 
     @staticmethod
     def build_model(model_path):
@@ -243,11 +254,14 @@ class YOLOE(Model):
         """
         if self.tracker is None:
             return np.empty((0, 8), dtype=np.float32)
+
+        rgb_frame = np.asarray(image.convert("RGB"))
+        bgr_frame = np.ascontiguousarray(rgb_frame[:, :, ::-1])
         return self.tracker.update(
             scores.flatten(),
             xyxy2xywh(bboxes),
             class_ids.flatten(),
-            np.asarray(image),
+            bgr_frame,
         )
 
     def set_auto_labeling_reset_tracker(self) -> None:
@@ -304,21 +318,20 @@ class YOLOE(Model):
 
         if self.tracker is not None and image is not None:
             tracks = self._update_tracker(bboxes, scores, class_ids, image)
-            if len(tracks) == 0:
-                return []
-
-            detection_indices = tracks[:, 7].astype(int)
-            valid = (detection_indices >= 0) & (
-                detection_indices < len(bboxes)
-            )
-            tracks = tracks[valid]
-            detection_indices = detection_indices[valid]
-            bboxes = tracks[:, :4]
-            track_ids = tracks[:, 4].astype(int)
-            scores = tracks[:, 5]
-            labels = labels[detection_indices]
-            if masks is not None:
-                masks = masks[detection_indices]
+            if len(tracks) > 0:
+                detection_indices = tracks[:, 7].astype(int)
+                valid = (detection_indices >= 0) & (
+                    detection_indices < len(bboxes)
+                )
+                tracks = tracks[valid]
+                detection_indices = detection_indices[valid]
+                if len(tracks) > 0:
+                    bboxes = tracks[:, :4]
+                    track_ids = tracks[:, 4].astype(int)
+                    scores = tracks[:, 5]
+                    labels = labels[detection_indices]
+                    if masks is not None:
+                        masks = masks[detection_indices]
         shapes = []
 
         # Generate rectangle shapes

--- a/anylabeling/services/auto_labeling/yoloe.py
+++ b/anylabeling/services/auto_labeling/yoloe.py
@@ -121,6 +121,7 @@ class YOLOE(Model):
         # Cache text prompt state to avoid unnecessary model rebuilds
         self._current_text_prompt = None
         self._prompt_free_initialized = False
+        self._active_tracker_context = None
 
         # Model configuration
         input_width = self.config.get("input_width", 640)
@@ -253,6 +254,23 @@ class YOLOE(Model):
         """Reset all YOLOE track identities and temporal state."""
         if self.tracker is not None:
             self.tracker.reset()
+
+    def _activate_tracker_context(
+        self, mode: str, class_names: Optional[list[str]] = None
+    ) -> None:
+        """Reset identities before the detector vocabulary changes.
+
+        Args:
+            mode (str): Active ``text``, ``visual``, or ``prompt_free`` mode.
+            class_names (Optional[list[str]]): Ordered text-prompt vocabulary.
+        """
+        context = (mode, tuple(class_names or ()))
+        if (
+            self._active_tracker_context is not None
+            and self._active_tracker_context != context
+        ):
+            self.set_auto_labeling_reset_tracker()
+        self._active_tracker_context = context
 
     def postprocess(
         self, results: Any, image: Optional[Image.Image] = None
@@ -429,6 +447,7 @@ class YOLOE(Model):
 
         # Visual prompting mode
         if self.marks:
+            self._activate_tracker_context("visual")
             bboxes = []
             logger.debug(f"marks: {self.marks}")
             for mark in self.marks:
@@ -452,15 +471,8 @@ class YOLOE(Model):
         # Text prompting mode
         elif text_prompt:
             texts = self._parse_text_prompt(text_prompt)
-
-            # Reset text model if prompt changed
-            if self.text_prompt is None:
-                self.text_prompt = texts
-            else:
-                if self.text_prompt != texts:
-                    self._text_model = None
-                    self.text_prompt = texts
-                    self.set_auto_labeling_reset_tracker()
+            self._activate_tracker_context("text", texts)
+            self.text_prompt = texts
             logger.debug(f"Input texts: {texts}")
 
             model = self._get_text_model(texts)
@@ -475,6 +487,7 @@ class YOLOE(Model):
 
         # Prompt-free mode
         else:
+            self._activate_tracker_context("prompt_free")
             model = self._get_prompt_free_model()
             results = model.predict(
                 source=image,

--- a/anylabeling/services/auto_labeling/yoloe.py
+++ b/anylabeling/services/auto_labeling/yoloe.py
@@ -325,13 +325,10 @@ class YOLOE(Model):
                 )
                 tracks = tracks[valid]
                 detection_indices = detection_indices[valid]
-                if len(tracks) > 0:
-                    bboxes = tracks[:, :4]
-                    track_ids = tracks[:, 4].astype(int)
-                    scores = tracks[:, 5]
-                    labels = labels[detection_indices]
-                    if masks is not None:
-                        masks = masks[detection_indices]
+                for index, track in zip(detection_indices, tracks):
+                    bboxes[index] = track[:4]
+                    track_ids[index] = int(track[4])
+                    scores[index] = track[5]
         shapes = []
 
         # Generate rectangle shapes

--- a/examples/grounding/yoloe/README.md
+++ b/examples/grounding/yoloe/README.md
@@ -135,3 +135,29 @@ Process multiple images efficiently using consistent detection parameters.
 - **Prompt-Free:** Leave text field empty to use configured class vocabulary for all images
 
 > **Note:** Visual prompting is not available in batch mode due to its interactive nature.
+
+## Open-Vocabulary Video Tracking
+
+Load the built-in `YOLOE-11-S-TrackTrack` configuration to assign a stable
+`group_id` to each detected instance across consecutive video frames. The
+`group_id` is the object's `track_id` and is preserved by MOT and MOTS export.
+
+The tracking configuration supports text prompting and prompt-free detection:
+
+1. Load a video or an ordered directory of video frames.
+2. Select `YOLOE-11-S-TrackTrack` from the model list.
+3. Enter one or more object names, or leave the text field empty to use the
+   configured vocabulary.
+4. Run the current frame and verify the detections.
+5. Press `Ctrl+M` on Windows/Linux or `Cmd+M` on macOS to process the remaining
+   frames.
+6. Use the Group ID Manager (`Alt+G`) to review or correct object identities.
+
+Run `Reset Tracker` before starting a different video. Changing the text prompt
+automatically resets the tracker because numeric class IDs belong to the active
+prompt vocabulary.
+
+Tracking can recover brief missed detections within `track_buffer`. Long
+occlusions, visually similar instances, abrupt camera cuts, and fast small
+objects can still cause identity switches. Review these cases before exporting
+training data.

--- a/tests/test_models/test_yoloe.py
+++ b/tests/test_models/test_yoloe.py
@@ -3,6 +3,8 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+import numpy as np
+
 from anylabeling.services.auto_labeling import yoloe
 
 
@@ -75,6 +77,44 @@ class TestYoloeEmbeddingModel(unittest.TestCase):
         inner_model.set_classes.assert_called_once_with(["cat"], "embeddings")
         inner_model.fuse.assert_called_once_with()
         self.assertEqual(vocab, ["first", "second"])
+
+
+class TestYoloeTracking(unittest.TestCase):
+    def test_update_tracker_uses_detection_indices(self):
+        tracker = mock.Mock()
+        tracker.update.return_value = np.array(
+            [[10, 20, 30, 40, 7, 0.9, 1, 0]], dtype=np.float32
+        )
+        instance = SimpleNamespace(tracker=tracker)
+        bboxes = np.array([[10, 20, 30, 40]], dtype=np.float32)
+        scores = np.array([0.9], dtype=np.float32)
+        class_ids = np.array([1], dtype=np.float32)
+        image = mock.Mock()
+
+        with mock.patch.object(
+            yoloe, "xyxy2xywh", return_value="xywh"
+        ) as convert:
+            with mock.patch.object(yoloe.np, "asarray", return_value="frame"):
+                result = yoloe.YOLOE._update_tracker(
+                    instance, bboxes, scores, class_ids, image
+                )
+
+        convert.assert_called_once_with(bboxes)
+        tracker.update.assert_called_once()
+        args = tracker.update.call_args.args
+        np.testing.assert_array_equal(args[0], scores)
+        self.assertEqual(args[1], "xywh")
+        np.testing.assert_array_equal(args[2], class_ids)
+        self.assertEqual(args[3], "frame")
+        np.testing.assert_array_equal(result, tracker.update.return_value)
+
+    def test_reset_tracker_clears_temporal_identity(self):
+        tracker = mock.Mock()
+        instance = SimpleNamespace(tracker=tracker)
+
+        yoloe.YOLOE.set_auto_labeling_reset_tracker(instance)
+
+        tracker.reset.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/tests/test_models/test_yoloe.py
+++ b/tests/test_models/test_yoloe.py
@@ -4,11 +4,43 @@ from types import SimpleNamespace
 from unittest import mock
 
 import numpy as np
+from PIL import Image
 
 from anylabeling.services.auto_labeling import (
     _AUTO_LABELING_RESET_TRACKER_MODELS,
 )
 from anylabeling.services.auto_labeling import yoloe
+
+
+class _FakeDetections:
+    """Provide deterministic YOLOE detections for post-processing tests."""
+
+    xyxy = np.asarray([[0, 0, 10, 10], [20, 20, 30, 30]], dtype=np.float32)
+    class_id = np.asarray([0, 1], dtype=np.int64)
+    confidence = np.asarray([0.6, 0.9], dtype=np.float32)
+    mask = np.asarray(
+        [
+            [[1, 0], [0, 0]],
+            [[0, 0], [0, 1]],
+        ],
+        dtype=np.uint8,
+    )
+
+    def __getitem__(self, key: str) -> np.ndarray:
+        """Return a named supervision data field.
+
+        Args:
+            key (str): Requested supervision field name.
+
+        Returns:
+            np.ndarray: Class names for the two fake detections.
+
+        Raises:
+            KeyError: If a field other than ``class_name`` is requested.
+        """
+        if key != "class_name":
+            raise KeyError(key)
+        return np.asarray(["person", "vehicle"])
 
 
 class TestYoloeEmbeddingModel(unittest.TestCase):
@@ -83,18 +115,42 @@ class TestYoloeEmbeddingModel(unittest.TestCase):
 
 
 class TestYoloeTracking(unittest.TestCase):
-    def test_yoloe_is_registered_for_tracker_reset(self):
+    """Verify YOLOE tracking integration without loading model weights."""
+
+    def test_yoloe_is_registered_for_tracker_reset(self) -> None:
+        """Verify model-manager reset dispatch includes YOLOE."""
         self.assertIn("yoloe", _AUTO_LABELING_RESET_TRACKER_MODELS)
 
-    def test_tracker_resets_when_prompt_context_changes(self):
+    def test_tracker_widgets_are_only_shown_when_configured(self) -> None:
+        """Verify legacy YOLOE configurations retain their existing UI."""
+        without_tracker = SimpleNamespace(
+            Meta=yoloe.YOLOE.Meta,
+            tracker=None,
+        )
+        with_tracker = SimpleNamespace(
+            Meta=yoloe.YOLOE.Meta,
+            tracker=mock.Mock(),
+        )
+
+        legacy_widgets = yoloe.YOLOE.get_required_widgets(without_tracker)
+        tracking_widgets = yoloe.YOLOE.get_required_widgets(with_tracker)
+
+        self.assertNotIn("button_reset_tracker", legacy_widgets)
+        self.assertIn("button_reset_tracker", tracking_widgets)
+
+    def test_tracker_resets_when_prompt_context_changes(self) -> None:
+        """Verify identities reset whenever the active vocabulary changes."""
         tracker = mock.Mock()
         instance = SimpleNamespace(
             tracker=tracker,
             _active_tracker_context=None,
         )
-        instance.set_auto_labeling_reset_tracker = lambda: (
+
+        def reset_tracker() -> None:
+            """Dispatch the reset method through the lightweight fixture."""
             yoloe.YOLOE.set_auto_labeling_reset_tracker(instance)
-        )
+
+        instance.set_auto_labeling_reset_tracker = reset_tracker
 
         yoloe.YOLOE._activate_tracker_context(instance, "text", ["person"])
         yoloe.YOLOE._activate_tracker_context(instance, "text", ["person"])
@@ -106,29 +162,10 @@ class TestYoloeTracking(unittest.TestCase):
 
         self.assertEqual(tracker.reset.call_count, 3)
 
-    def test_postprocess_preserves_mask_detection_index_and_group_id(self):
-        class FakeDetections:
-            """Two detections whose tracker order is deliberately reversed."""
-
-            xyxy = np.asarray(
-                [[0, 0, 10, 10], [20, 20, 30, 30]], dtype=np.float32
-            )
-            class_id = np.asarray([0, 1], dtype=np.int64)
-            confidence = np.asarray([0.6, 0.9], dtype=np.float32)
-            mask = np.asarray(
-                [
-                    [[1, 0], [0, 0]],
-                    [[0, 0], [0, 1]],
-                ],
-                dtype=np.uint8,
-            )
-
-            def __getitem__(self, key):
-                """Return class names for the supervision data field."""
-                if key != "class_name":
-                    raise KeyError(key)
-                return np.asarray(["person", "vehicle"])
-
+    def test_postprocess_preserves_mask_detection_index_and_group_id(
+        self,
+    ) -> None:
+        """Verify reordered tracks retain the corresponding mask and ID."""
         tracks = np.asarray(
             [
                 [20, 20, 30, 30, 42, 0.9, 1, 1],
@@ -144,12 +181,20 @@ class TestYoloeTracking(unittest.TestCase):
         )
         supervision = SimpleNamespace(
             Detections=SimpleNamespace(
-                from_ultralytics=mock.Mock(return_value=FakeDetections())
+                from_ultralytics=mock.Mock(return_value=_FakeDetections())
             )
         )
-        converted_masks = []
+        converted_masks: list[np.ndarray] = []
 
-        def fake_mask_to_polygons(mask):
+        def fake_mask_to_polygons(mask: np.ndarray) -> list[np.ndarray]:
+            """Record a mask and return a minimal valid polygon.
+
+            Args:
+                mask (np.ndarray): Instance mask selected by detection index.
+
+            Returns:
+                list[np.ndarray]: One triangular polygon.
+            """
             converted_masks.append(mask.copy())
             return [np.asarray([[0, 0], [1, 0], [1, 1]])]
 
@@ -171,13 +216,76 @@ class TestYoloeTracking(unittest.TestCase):
         )
         self.assertEqual([shape.group_id for shape in shapes], [42, 17])
         np.testing.assert_array_equal(
-            converted_masks[0], FakeDetections.mask[1]
+            converted_masks[0], _FakeDetections.mask[1]
         )
         np.testing.assert_array_equal(
-            converted_masks[1], FakeDetections.mask[0]
+            converted_masks[1], _FakeDetections.mask[0]
         )
 
-    def test_update_tracker_uses_detection_indices(self):
+    def test_empty_tracker_output_preserves_raw_detections(self) -> None:
+        """Verify an empty tracker result never drops detector annotations."""
+        instance = SimpleNamespace(
+            tracker=mock.Mock(),
+            output_mode="rectangle",
+            with_mask=True,
+            _update_tracker=mock.Mock(
+                return_value=np.empty((0, 8), dtype=np.float32)
+            ),
+        )
+        supervision = SimpleNamespace(
+            Detections=SimpleNamespace(
+                from_ultralytics=mock.Mock(return_value=_FakeDetections())
+            )
+        )
+        converted_masks: list[np.ndarray] = []
+
+        def fake_mask_to_polygons(mask: np.ndarray) -> list[np.ndarray]:
+            """Record a raw mask and return a minimal valid polygon.
+
+            Args:
+                mask (np.ndarray): Raw detector mask.
+
+            Returns:
+                list[np.ndarray]: One triangular polygon.
+            """
+            converted_masks.append(mask.copy())
+            return [np.asarray([[0, 0], [1, 0], [1, 1]])]
+
+        with (
+            mock.patch.object(yoloe, "sv", supervision, create=True),
+            mock.patch.object(
+                yoloe,
+                "mask_to_polygons",
+                side_effect=fake_mask_to_polygons,
+                create=True,
+            ),
+        ):
+            shapes = yoloe.YOLOE.postprocess(
+                instance, [object()], image=object()
+            )
+
+        rectangles = shapes[:2]
+        polygons = shapes[2:]
+        self.assertEqual(
+            [shape.label for shape in rectangles], ["person", "vehicle"]
+        )
+        self.assertEqual([shape.group_id for shape in shapes], [None] * 4)
+        self.assertEqual(
+            [(point.x(), point.y()) for point in rectangles[0].points],
+            [(0.0, 0.0), (10.0, 0.0), (10.0, 10.0), (0.0, 10.0)],
+        )
+        self.assertEqual(
+            [shape.label for shape in polygons], ["person", "vehicle"]
+        )
+        np.testing.assert_array_equal(
+            converted_masks[0], _FakeDetections.mask[0]
+        )
+        np.testing.assert_array_equal(
+            converted_masks[1], _FakeDetections.mask[1]
+        )
+
+    def test_update_tracker_converts_pil_rgb_to_bgr(self) -> None:
+        """Verify GMC receives the BGR channel order expected by OpenCV."""
         tracker = mock.Mock()
         tracker.update.return_value = np.array(
             [[10, 20, 30, 40, 7, 0.9, 1, 0]], dtype=np.float32
@@ -186,15 +294,14 @@ class TestYoloeTracking(unittest.TestCase):
         bboxes = np.array([[10, 20, 30, 40]], dtype=np.float32)
         scores = np.array([0.9], dtype=np.float32)
         class_ids = np.array([1], dtype=np.float32)
-        image = mock.Mock()
+        image = Image.new("RGB", (2, 2), color=(10, 20, 30))
 
         with mock.patch.object(
             yoloe, "xyxy2xywh", return_value="xywh"
         ) as convert:
-            with mock.patch.object(yoloe.np, "asarray", return_value="frame"):
-                result = yoloe.YOLOE._update_tracker(
-                    instance, bboxes, scores, class_ids, image
-                )
+            result = yoloe.YOLOE._update_tracker(
+                instance, bboxes, scores, class_ids, image
+            )
 
         convert.assert_called_once_with(bboxes)
         tracker.update.assert_called_once()
@@ -202,10 +309,61 @@ class TestYoloeTracking(unittest.TestCase):
         np.testing.assert_array_equal(args[0], scores)
         self.assertEqual(args[1], "xywh")
         np.testing.assert_array_equal(args[2], class_ids)
-        self.assertEqual(args[3], "frame")
+        np.testing.assert_array_equal(
+            args[3], np.full((2, 2, 3), [30, 20, 10], dtype=np.uint8)
+        )
+        self.assertTrue(args[3].flags.c_contiguous)
         np.testing.assert_array_equal(result, tracker.update.return_value)
 
-    def test_reset_tracker_clears_temporal_identity(self):
+    def test_tracktrack_keeps_id_across_two_cpu_frames(self) -> None:
+        """Verify real TrackTrack association keeps one ID for two frames."""
+        tracker = yoloe.YOLOE._build_tracker(
+            {
+                "tracker_type": "tracktrack",
+                "track_high_thresh": 0.5,
+                "track_low_thresh": 0.1,
+                "new_track_thresh": 0.6,
+                "track_buffer": 30,
+                "match_thresh": 0.7,
+                "lost_match_thr": 0.0,
+                "iou_weight": 0.5,
+                "conf_weight": 0.1,
+                "angle_weight": 0.05,
+                "penalty_p": 0.2,
+                "reduce_step": 0.05,
+                "tai_thr": 0.55,
+                "min_track_len": 1,
+                "gmc_method": "none",
+            }
+        )
+        instance = SimpleNamespace(tracker=tracker)
+        scores = np.asarray([0.9], dtype=np.float32)
+        class_ids = np.asarray([0], dtype=np.int64)
+        frame = Image.new("RGB", (32, 32), color=(0, 0, 0))
+
+        first = yoloe.YOLOE._update_tracker(
+            instance,
+            np.asarray([[10, 10, 20, 20]], dtype=np.float32),
+            scores,
+            class_ids,
+            frame,
+        )
+        second = yoloe.YOLOE._update_tracker(
+            instance,
+            np.asarray([[11, 10, 21, 20]], dtype=np.float32),
+            scores,
+            class_ids,
+            frame,
+        )
+
+        self.assertEqual(first.shape, (1, 8))
+        self.assertEqual(second.shape, (1, 8))
+        self.assertEqual(int(first[0, 4]), int(second[0, 4]))
+        self.assertEqual(int(first[0, 7]), 0)
+        self.assertEqual(int(second[0, 7]), 0)
+
+    def test_reset_tracker_clears_temporal_identity(self) -> None:
+        """Verify the reset control clears all tracker state."""
         tracker = mock.Mock()
         instance = SimpleNamespace(tracker=tracker)
 

--- a/tests/test_models/test_yoloe.py
+++ b/tests/test_models/test_yoloe.py
@@ -165,7 +165,7 @@ class TestYoloeTracking(unittest.TestCase):
     def test_postprocess_preserves_mask_detection_index_and_group_id(
         self,
     ) -> None:
-        """Verify reordered tracks retain the corresponding mask and ID."""
+        """Verify write-back preserves masks and IDs in detection order."""
         tracks = np.asarray(
             [
                 [20, 20, 30, 30, 42, 0.9, 1, 1],
@@ -212,14 +212,78 @@ class TestYoloeTracking(unittest.TestCase):
             )
 
         self.assertEqual(
-            [shape.label for shape in shapes], ["vehicle", "person"]
+            [shape.label for shape in shapes], ["person", "vehicle"]
         )
-        self.assertEqual([shape.group_id for shape in shapes], [42, 17])
+        self.assertEqual([shape.group_id for shape in shapes], [17, 42])
         np.testing.assert_array_equal(
-            converted_masks[0], _FakeDetections.mask[1]
+            converted_masks[0], _FakeDetections.mask[0]
         )
         np.testing.assert_array_equal(
-            converted_masks[1], _FakeDetections.mask[0]
+            converted_masks[1], _FakeDetections.mask[1]
+        )
+
+    def test_partial_tracker_output_keeps_unconfirmed_new_targets(
+        self,
+    ) -> None:
+        """One confirmed track plus one new target must both stay visible."""
+        tracks = np.asarray(
+            [[0, 0, 10, 10, 17, 0.6, 0, 0]],
+            dtype=np.float32,
+        )
+        instance = SimpleNamespace(
+            tracker=mock.Mock(),
+            output_mode="rectangle",
+            with_mask=True,
+            _update_tracker=mock.Mock(return_value=tracks),
+        )
+        supervision = SimpleNamespace(
+            Detections=SimpleNamespace(
+                from_ultralytics=mock.Mock(return_value=_FakeDetections())
+            )
+        )
+        converted_masks: list[np.ndarray] = []
+
+        def fake_mask_to_polygons(mask: np.ndarray) -> list[np.ndarray]:
+            """Record a mask and return a minimal valid polygon.
+
+            Args:
+                mask (np.ndarray): Instance mask selected by detection index.
+
+            Returns:
+                list[np.ndarray]: One triangular polygon.
+            """
+            converted_masks.append(mask.copy())
+            return [np.asarray([[0, 0], [1, 0], [1, 1]])]
+
+        with (
+            mock.patch.object(yoloe, "sv", supervision, create=True),
+            mock.patch.object(
+                yoloe,
+                "mask_to_polygons",
+                side_effect=fake_mask_to_polygons,
+                create=True,
+            ),
+        ):
+            shapes = yoloe.YOLOE.postprocess(
+                instance, [object()], image=object()
+            )
+
+        rectangles = shapes[:2]
+        polygons = shapes[2:]
+        self.assertEqual(
+            [shape.label for shape in rectangles], ["person", "vehicle"]
+        )
+        self.assertEqual(
+            [shape.group_id for shape in shapes], [17, None, 17, None]
+        )
+        self.assertEqual(
+            [shape.label for shape in polygons], ["person", "vehicle"]
+        )
+        np.testing.assert_array_equal(
+            converted_masks[0], _FakeDetections.mask[0]
+        )
+        np.testing.assert_array_equal(
+            converted_masks[1], _FakeDetections.mask[1]
         )
 
     def test_empty_tracker_output_preserves_raw_detections(self) -> None:

--- a/tests/test_models/test_yoloe.py
+++ b/tests/test_models/test_yoloe.py
@@ -5,6 +5,9 @@ from unittest import mock
 
 import numpy as np
 
+from anylabeling.services.auto_labeling import (
+    _AUTO_LABELING_RESET_TRACKER_MODELS,
+)
 from anylabeling.services.auto_labeling import yoloe
 
 
@@ -80,6 +83,100 @@ class TestYoloeEmbeddingModel(unittest.TestCase):
 
 
 class TestYoloeTracking(unittest.TestCase):
+    def test_yoloe_is_registered_for_tracker_reset(self):
+        self.assertIn("yoloe", _AUTO_LABELING_RESET_TRACKER_MODELS)
+
+    def test_tracker_resets_when_prompt_context_changes(self):
+        tracker = mock.Mock()
+        instance = SimpleNamespace(
+            tracker=tracker,
+            _active_tracker_context=None,
+        )
+        instance.set_auto_labeling_reset_tracker = lambda: (
+            yoloe.YOLOE.set_auto_labeling_reset_tracker(instance)
+        )
+
+        yoloe.YOLOE._activate_tracker_context(instance, "text", ["person"])
+        yoloe.YOLOE._activate_tracker_context(instance, "text", ["person"])
+        tracker.reset.assert_not_called()
+
+        yoloe.YOLOE._activate_tracker_context(instance, "text", ["vehicle"])
+        yoloe.YOLOE._activate_tracker_context(instance, "prompt_free")
+        yoloe.YOLOE._activate_tracker_context(instance, "visual")
+
+        self.assertEqual(tracker.reset.call_count, 3)
+
+    def test_postprocess_preserves_mask_detection_index_and_group_id(self):
+        class FakeDetections:
+            """Two detections whose tracker order is deliberately reversed."""
+
+            xyxy = np.asarray(
+                [[0, 0, 10, 10], [20, 20, 30, 30]], dtype=np.float32
+            )
+            class_id = np.asarray([0, 1], dtype=np.int64)
+            confidence = np.asarray([0.6, 0.9], dtype=np.float32)
+            mask = np.asarray(
+                [
+                    [[1, 0], [0, 0]],
+                    [[0, 0], [0, 1]],
+                ],
+                dtype=np.uint8,
+            )
+
+            def __getitem__(self, key):
+                """Return class names for the supervision data field."""
+                if key != "class_name":
+                    raise KeyError(key)
+                return np.asarray(["person", "vehicle"])
+
+        tracks = np.asarray(
+            [
+                [20, 20, 30, 30, 42, 0.9, 1, 1],
+                [0, 0, 10, 10, 17, 0.6, 0, 0],
+            ],
+            dtype=np.float32,
+        )
+        instance = SimpleNamespace(
+            tracker=mock.Mock(),
+            output_mode="polygon",
+            with_mask=True,
+            _update_tracker=mock.Mock(return_value=tracks),
+        )
+        supervision = SimpleNamespace(
+            Detections=SimpleNamespace(
+                from_ultralytics=mock.Mock(return_value=FakeDetections())
+            )
+        )
+        converted_masks = []
+
+        def fake_mask_to_polygons(mask):
+            converted_masks.append(mask.copy())
+            return [np.asarray([[0, 0], [1, 0], [1, 1]])]
+
+        with (
+            mock.patch.object(yoloe, "sv", supervision, create=True),
+            mock.patch.object(
+                yoloe,
+                "mask_to_polygons",
+                side_effect=fake_mask_to_polygons,
+                create=True,
+            ),
+        ):
+            shapes = yoloe.YOLOE.postprocess(
+                instance, [object()], image=object()
+            )
+
+        self.assertEqual(
+            [shape.label for shape in shapes], ["vehicle", "person"]
+        )
+        self.assertEqual([shape.group_id for shape in shapes], [42, 17])
+        np.testing.assert_array_equal(
+            converted_masks[0], FakeDetections.mask[1]
+        )
+        np.testing.assert_array_equal(
+            converted_masks[1], FakeDetections.mask[0]
+        )
+
     def test_update_tracker_uses_detection_indices(self):
         tracker = mock.Mock()
         tracker.update.return_value = np.array(


### PR DESCRIPTION
## CLA

Please confirm that you agree to the [Contributor License Agreement (CLA)](https://github.com/CVHub520/X-AnyLabeling/blob/main/CLA.md) by checking the box below:

- [x] I have read and agree to the CLA.

## Summary

Add optional multi-object tracking to YOLOE so open-vocabulary rectangle and polygon annotations can retain stable `group_id` values across consecutive video frames.

## Motivation

YOLOE currently annotates each frame independently. During video batch annotation, detections of the same object therefore have no persistent identity for Group ID Manager, MOT, or MOTS workflows.

## Changes

- add optional ByteTrack, BoT-SORT, and TrackTrack construction through the existing tracker configuration schema;
- add a built-in `YOLOE-11-S-TrackTrack` configuration;
- map confirmed tracker IDs to `Shape.group_id` for rectangle and polygon output;
- preserve unconfirmed YOLOE detections with `group_id=None` while a tracker initializes or returns no valid association;
- preserve detector-to-mask indexing when tracker output order changes;
- convert PIL RGB frames to contiguous BGR arrays before tracker GMC;
- reset tracker state when the prompt vocabulary changes or the user clicks Reset Tracker;
- show Reset Tracker only for YOLOE configurations that initialize a tracker;
- document the video tracking workflow and current identity limitations;
- add focused unit coverage and a two-frame CPU TrackTrack integration test.

Existing YOLOE configurations do not define a tracker and retain their current frame-independent behavior and widget set.

## Validation

- `python -m pytest tests/test_models/test_yoloe.py -q`: 11 passed
- real TrackTrack CPU association retains one ID across two synthetic frames
- Black check passed for changed Python files
- Flake8 passed for changed Python files
- Python compilation passed
- YAML model registry check passed
- `git diff --check` passed

## Scope

This PR contains only YOLOE tracking. SAM 2 propagation, occlusion recovery, and basketball-specific temporal experiments are intentionally excluded.

The PR remains a draft until the CLA is confirmed and the final reproducibility evidence is attached.
