### PR TITLE
Fix mask export for null images

### DIFF
--- a/anylabeling/views/labeling/label_converter.py
+++ b/anylabeling/views/labeling/label_converter.py
@@ -1784,6 +1784,55 @@ class LabelConverter:
                     f"{x0} {y0} {x1} {y1} {x2} {y2} {x3} {y3} {label} {int(difficult)}\n"
                 )
 
+    def write_empty_mask(
+        self,
+        output_file: str,
+        mapping_table: Dict[str, Any],
+        image_width: int,
+        image_height: int,
+    ) -> None:
+        """
+        Writes a blank mask image using the configured mask output format.
+
+        Args:
+            output_file (str): Destination path for the generated PNG mask.
+            mapping_table (Dict[str, Any]): Mask color map configuration.
+            image_width (int): Width of the source image in pixels.
+            image_height (int): Height of the source image in pixels.
+        """
+        image_shape = (image_height, image_width)
+        output_format = mapping_table["type"]
+        if output_format == "grayscale":
+            empty_mask = np.zeros(image_shape, dtype=np.uint8)
+            cv2.imencode(".png", empty_mask)[1].tofile(output_file)
+        elif output_format == "rgb":
+            empty_mask = np.zeros(
+                (image_height, image_width, 3), dtype=np.uint8
+            )
+            cv2.imencode(".png", empty_mask)[1].tofile(output_file)
+        else:
+            raise ValueError("Invalid output format specified")
+
+    def custom_image_to_empty_mask(
+        self,
+        image_file: str,
+        output_file: str,
+        mapping_table: Dict[str, Any],
+    ) -> None:
+        """
+        Creates a blank mask from an image file when no label JSON exists.
+
+        Args:
+            image_file (str): Source image path used to determine mask size.
+            output_file (str): Destination path for the generated PNG mask.
+            mapping_table (Dict[str, Any]): Mask color map configuration.
+        """
+        with Image.open(image_file) as image:
+            image_width, image_height = image.size
+        self.write_empty_mask(
+            output_file, mapping_table, image_width, image_height
+        )
+
     def custom_to_mask(self, input_file, output_file, mapping_table):
         data = self.read_json(input_file)
         image_width = data["imageWidth"]
@@ -1813,7 +1862,7 @@ class LabelConverter:
         if output_format not in ["grayscale", "rgb"]:
             raise ValueError("Invalid output format specified")
         mapping_color = mapping_table["colors"]
-        if output_format == "grayscale" and polygons:
+        if output_format == "grayscale":
             # Initialize binary_mask
             binary_mask = np.zeros(image_shape, dtype=np.uint8)
             # Sort polygons by area to handle overlapping (larger areas first)
@@ -1836,7 +1885,7 @@ class LabelConverter:
 
             cv2.imencode(".png", binary_mask)[1].tofile(output_file)
 
-        elif output_format == "rgb" and polygons:
+        elif output_format == "rgb":
             # Initialize rgb_mask
             color_mask = np.zeros(
                 (image_height, image_width, 3), dtype=np.uint8

--- a/anylabeling/views/labeling/utils/export.py
+++ b/anylabeling/views/labeling/utils/export.py
@@ -971,6 +971,21 @@ def export_mask_annotation(self):
     path_layout.addLayout(path_input_layout)
     layout.addLayout(path_layout)
 
+    options_label = QtWidgets.QLabel(self.tr("Export Options"))
+    layout.addWidget(options_label)
+
+    include_null_images_checkbox = QtWidgets.QCheckBox(
+        self.tr("Include images without labels?")
+    )
+    include_null_images_checkbox.setChecked(False)
+    layout.addWidget(include_null_images_checkbox)
+
+    only_checked_images_checkbox = QtWidgets.QCheckBox(
+        self.tr("Only export checked images?")
+    )
+    only_checked_images_checkbox.setChecked(False)
+    layout.addWidget(only_checked_images_checkbox)
+
     button_layout = QHBoxLayout()
     button_layout.setContentsMargins(0, 16, 0, 0)
     button_layout.setSpacing(8)
@@ -995,6 +1010,8 @@ def export_mask_annotation(self):
         return
 
     save_path = path_edit.text()
+    include_null_images = include_null_images_checkbox.isChecked()
+    only_checked_images = only_checked_images_checkbox.isChecked()
     if osp.exists(save_path):
         msg_box = QtWidgets.QMessageBox(self)
         msg_box.setIcon(QtWidgets.QMessageBox.Icon.Warning)
@@ -1052,12 +1069,26 @@ def export_mask_annotation(self):
                 src_file = osp.join(osp.dirname(image_file), label_file_name)
             dst_file = osp.join(save_path, dst_file_name)
 
-            if not osp.exists(src_file):
+            label_file_exists = osp.exists(src_file)
+            if only_checked_images:
+                if not label_file_exists:
+                    progress_dialog.setValue(i + 1)
+                    continue
+                if not converter.read_json(src_file).get("checked", False):
+                    progress_dialog.setValue(i + 1)
+                    continue
+
+            if not label_file_exists:
+                if include_null_images:
+                    converter.custom_image_to_empty_mask(
+                        image_file, dst_file, mapping_table
+                    )
+                progress_dialog.setValue(i + 1)
                 continue
 
             converter.custom_to_mask(src_file, dst_file, mapping_table)
 
-            progress_dialog.setValue(i)
+            progress_dialog.setValue(i + 1)
             if progress_dialog.wasCanceled():
                 break
 

--- a/tests/test_utils/test_label_converter.py
+++ b/tests/test_utils/test_label_converter.py
@@ -5,6 +5,9 @@ import unittest
 from unittest import mock
 
 import yaml
+import cv2
+import numpy as np
+from PIL import Image
 
 from anylabeling.views.labeling.label_converter import LabelConverter
 
@@ -109,6 +112,53 @@ class TestLabelConverterObbBounds(unittest.TestCase):
 
         with open(output_file, "r", encoding="utf-8") as f:
             self.assertEqual(f.read(), "")
+
+
+class TestLabelConverterMaskExport(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp_dir.cleanup)
+        self.converter = LabelConverter()
+        self.mapping_table = {"type": "grayscale", "colors": {"cat": 1}}
+
+    def _write_label_file(self, shapes):
+        label_file = os.path.join(self.temp_dir.name, "label.json")
+        data = {
+            "imagePath": "image.jpg",
+            "imageWidth": 4,
+            "imageHeight": 3,
+            "shapes": shapes,
+        }
+        with open(label_file, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        return label_file
+
+    def test_custom_to_mask_writes_blank_mask_for_empty_labels(self):
+        label_file = self._write_label_file([])
+        output_file = os.path.join(self.temp_dir.name, "mask.png")
+
+        self.converter.custom_to_mask(
+            label_file, output_file, self.mapping_table
+        )
+
+        mask = cv2.imread(output_file, cv2.IMREAD_UNCHANGED)
+        self.assertIsNotNone(mask)
+        self.assertEqual(mask.shape, (3, 4))
+        self.assertTrue(np.all(mask == 0))
+
+    def test_custom_image_to_empty_mask_uses_source_image_size(self):
+        image_file = os.path.join(self.temp_dir.name, "image.png")
+        output_file = os.path.join(self.temp_dir.name, "mask.png")
+        Image.new("RGB", (5, 2), color=(255, 255, 255)).save(image_file)
+
+        self.converter.custom_image_to_empty_mask(
+            image_file, output_file, self.mapping_table
+        )
+
+        mask = cv2.imread(output_file, cv2.IMREAD_UNCHANGED)
+        self.assertIsNotNone(mask)
+        self.assertEqual(mask.shape, (2, 5))
+        self.assertTrue(np.all(mask == 0))
 
 
 class TestLabelConverterVocValidation(unittest.TestCase):


### PR DESCRIPTION
## CLA

Please confirm that you agree to the [Contributor License Agreement (CLA)](https://github.com/CVHub520/X-AnyLabeling/blob/main/CLA.md) by checking the box below:

- [x] I have read and agree to the CLA.

## Summary

- Write blank mask PNGs when a label JSON exists but contains no polygon annotations.
- Add a mask export option to include images without label files, producing blank masks sized from the source images.
- Add a mask export option to export only checked annotations.

Fixes #1422

## Tests

- `python -m pytest -q tests/test_utils/test_label_converter.py`
- `python -m compileall -q anylabeling/views/labeling/label_converter.py anylabeling/views/labeling/utils/export.py tests/test_utils/test_label_converter.py`
- `git diff --check`
