### PR TITLE
✨ feat(export): show failing image details for YOLO export errors

### DIFF
--- a/anylabeling/views/labeling/label_converter.py
+++ b/anylabeling/views/labeling/label_converter.py
@@ -1372,8 +1372,21 @@ class LabelConverter:
                 max_keypoints = max(
                     [len(kpts) for kpts in self.pose_classes.values()]
                 )
-                for data in pose_data.values():
+                for group_id, data in pose_data.items():
+                    if "box_label" not in data or not data.get("rectangle"):
+                        raise ValueError(
+                            f"Missing rectangle/box_label for pose "
+                            f"group_id={group_id} in {input_file}. "
+                            f"Each pose instance needs a rectangle with "
+                            f"the class label."
+                        )
                     box_label = data["box_label"]
+                    if box_label not in classes:
+                        raise ValueError(
+                            f"Unknown box_label '{box_label}' for pose "
+                            f"group_id={group_id} in {input_file}. "
+                            f"Expected one of: {classes}"
+                        )
                     box_index = classes.index(box_label)
                     kpt_names = self.pose_classes[box_label]
                     rectangle = data["rectangle"]

--- a/anylabeling/views/labeling/utils/export.py
+++ b/anylabeling/views/labeling/utils/export.py
@@ -309,8 +309,10 @@ def export_yolo_annotation(self, mode):
         get_progress_dialog_style(color="#1d1d1f", height=20)
     )
 
+    current_image_file = None
     try:
         for i, image_file in enumerate(image_list):
+            current_image_file = image_file
             image_file_name = osp.basename(image_file)
             dst_file_name = osp.splitext(image_file_name)[0] + ".txt"
 
@@ -351,15 +353,32 @@ def export_yolo_annotation(self, mode):
         popup.show_popup(self, popup_height=65, position="center")
 
     except Exception as e:
-        message = f"Error occurred while exporting annotations: {str(e)}"
         progress_dialog.close()
-        logger.error(message)
-        popup = Popup(
-            message,
-            self,
-            icon=new_icon_path("error", "svg"),
+        image_name = (
+            osp.basename(current_image_file) if current_image_file else ""
         )
-        popup.show_popup(self, position="center")
+        if current_image_file:
+            logger.error(
+                "Error occurred while exporting annotations for image:\n"
+                f"{current_image_file}\n{e}"
+            )
+        else:
+            logger.error(f"Error occurred while exporting annotations: {e}")
+
+        msg_box = QtWidgets.QMessageBox(self)
+        msg_box.setIcon(QtWidgets.QMessageBox.Icon.Critical)
+        msg_box.setWindowTitle(self.tr("Export Failed"))
+        if image_name:
+            msg_box.setText(self.tr("Failed on image: %s") % image_name)
+        else:
+            msg_box.setText(self.tr("Export failed."))
+        msg_box.setInformativeText(str(e))
+        if current_image_file:
+            msg_box.setDetailedText(
+                self.tr("Image path:\n%s") % current_image_file
+            )
+        msg_box.setStyleSheet(get_msg_box_style())
+        msg_box.exec()
 
 
 def export_voc_annotation(self, mode):


### PR DESCRIPTION
﻿## Summary
- YOLO 导出失败时，在界面用 `QMessageBox` 明确提示**失败图片名**、错误原因和完整路径，便于用户自行排查。
- YOLO-Pose 转换时，对缺少 `rectangle/box_label` 或未知 `box_label` 的情况抛出更清晰的 `ValueError`（含 `group_id` 与标注文件路径），避免只出现难以理解的 `'box_label'`。

## Motivation
导出 YOLO-Pose 时，若某个 `group_id` 只有关键点、缺少对应矩形框，当前只会报类似 `KeyError: 'box_label'`，且通过短时 Toast 提示，用户很难定位是哪张图片的问题。

## Test plan
- [ ] 导出正常的 YOLO-Pose 数据集，确认导出成功流程不受影响
- [ ] 构造一张仅有关键点、缺少 rectangle 的 pose 标注，确认弹窗展示失败图片名与详细原因
- [ ] 构造 `box_label` 不在 pose 配置类别中的样本，确认提示包含期望类别列表
- [ ] 确认日志中同样记录了完整图片路径
