### PR TITLE
Fix and refine canvas interaction for annotation precision

### DIFF
--- a/anylabeling/views/labeling/widgets/canvas.py
+++ b/anylabeling/views/labeling/widgets/canvas.py
@@ -25,7 +25,7 @@ CURSOR_GRAB = QtCore.Qt.CursorShape.OpenHandCursor
 AUTO_DECODE_DELAY_MS = 100
 MAX_AUTO_DECODE_MARKS = 42
 AUTO_DECODE_MOVE_THRESHOLD = 5.0
-MOVE_SPEED = 5.0
+MOVE_SPEED = 1.0
 LARGE_ROTATION_INCREMENT = math.radians(1.0)
 SMALL_ROTATION_INCREMENT = math.radians(0.1)
 ROTATION_HANDLE_DISTANCE = 32.0
@@ -2500,6 +2500,8 @@ class Canvas(
             self.override_cursor(CURSOR_DEFAULT)
             self.setToolTip("")
             self.setStatusTip("")
+            if self.h_shape_is_hovered and self.selected_shapes:
+                self.deselect_shape()
         self.vertex_selected.emit(self.h_vertex is not None)
 
         if prev_hover_shape != self.h_shape:
@@ -2891,6 +2893,7 @@ class Canvas(
                     self.h_shape is not None
                     and self.h_shape_is_selected
                     and not self.moving_shape
+                    and not self.h_shape_is_hovered
                 ):
                     self.selection_changed.emit(
                         [x for x in self.selected_shapes if x != self.h_shape]
@@ -4152,9 +4155,10 @@ class Canvas(
                     fill_color.blue(),
                     self.mask_opacity,
                 )
-                p.setPen(Qt.PenStyle.NoPen)
-                p.setBrush(fill_color_alpha)
-                p.drawPath(mask_path)
+                if not (self.moving_shape and shape.selected):
+                    p.setPen(Qt.PenStyle.NoPen)
+                    p.setBrush(fill_color_alpha)
+                    p.drawPath(mask_path)
 
                 outline_color = (
                     shape.select_line_color
@@ -4180,7 +4184,7 @@ class Canvas(
                 shape.fill = (
                     self._fill_drawing
                     and (shape.selected or shape == self.h_shape)
-                    and not (self.selected_vertex() and self.moving_shape)
+                    and not (self.moving_shape and shape.selected)
                 )
                 # Brush-edited shapes are drawn from their mask instead.
                 if not getattr(shape, "_brush_using_mask", False):


### PR DESCRIPTION
Changes:

1. **Fix keyboard movement after click** — Enable immediate keyboard-based nudging of the annotation box right after clicking to select a shape, without requiring additional interaction.
2. **Hide fill during transform** — Temporarily hide shape fill while dragging/resizing to keep boundaries visible; restore on release.
3. **Smarter auto-highlight selection** — Deselect shape immediately on mouse leave instead of locking until another shape is hovered.
4. **Finer keyboard precision** — Reduce arrow key movement step from 5px to 1px; smaller steps are more appropriate when using keyboard to finely adjust annotation boundaries.


I have read and agree to the CLA.
