### PR TITLE
feat: add reusable YOLOE visual prompt workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,8 @@ htmlcov/
 .coverage
 .coverage.*
 .cache
+tests/output/
+codex_visual_prompt_reference/
 nosetests.xml
 coverage.xml
 *.cover

--- a/anylabeling/services/auto_labeling/model_manager.py
+++ b/anylabeling/services/auto_labeling/model_manager.py
@@ -50,6 +50,7 @@ class ModelManager(QObject):
     output_modes_changed = pyqtSignal(dict, str)
     download_progress = pyqtSignal(int, int)
     download_finished = pyqtSignal()
+    visual_prompt_status_changed = pyqtSignal(dict)
 
     def __init__(self):
         super().__init__()
@@ -2350,6 +2351,284 @@ class ModelManager(QObject):
         ):
             return
         self.loaded_model_config["model"].set_auto_labeling_marks(marks)
+        if self.loaded_model_config["type"] == "yoloe":
+            self.visual_prompt_status_changed.emit(
+                self.get_visual_prompt_status()
+            )
+
+    def get_visual_prompt_status(self):
+        """Return UI-safe state for the loaded YOLOE visual prompt."""
+        with self.loaded_model_config_lock:
+            model_config = self.loaded_model_config
+        if model_config is None or model_config.get("type") != "yoloe":
+            return {
+                "state": "NO_VISUAL_PROMPT",
+                "ready": False,
+                "classes": [],
+            }
+
+        model = model_config["model"]
+        reference = model.visual_prompt_reference or {}
+        vpe = model.visual_prompt_vpe
+        return {
+            "state": model.get_visual_prompt_state(),
+            "ready": model.has_visual_prompt(),
+            "classes": list(model.visual_prompt_classes),
+            "reference_image": reference.get("image_path"),
+            "instance_count": reference.get("instance_count", 0),
+            "vpe_shape": list(vpe.shape) if vpe is not None else None,
+            "profile_name": getattr(model, "visual_prompt_profile_name", None),
+            "mark_count": len(model.marks),
+        }
+
+    def build_visual_prompt(self, reference_image, filename=None):
+        """Build a YOLOE VPE in the model execution worker."""
+        with self.loaded_model_config_lock:
+            model_config = self.loaded_model_config
+        if model_config is None or model_config.get("type") != "yoloe":
+            self.new_model_status.emit(
+                self.tr(
+                    "Load a YOLOE model before generating a visual prompt."
+                )
+            )
+            self.prediction_finished.emit()
+            return
+
+        try:
+            source = filename if filename else reference_image
+            vpe = model_config["model"].build_visual_prompt(source)
+            status = self.get_visual_prompt_status()
+            self.visual_prompt_status_changed.emit(status)
+            template = (
+                "Visual prompt generated successfully. "
+                "Instances: {instances}; class: {classes}; VPE shape: {shape}."
+            )
+            self.new_model_status.emit(
+                self.tr(template).format(
+                    instances=status["instance_count"],
+                    classes=", ".join(status["classes"]),
+                    shape=tuple(vpe.shape),
+                )
+            )
+        except Exception as e:  # noqa
+            logger.error(f"Error in build_visual_prompt: {e}")
+            template = "Error generating visual prompt: {error_message}"
+            self.new_model_status.emit(
+                self.tr(template).format(error_message=str(e))
+            )
+            self.visual_prompt_status_changed.emit(
+                self.get_visual_prompt_status()
+            )
+        self.prediction_finished.emit()
+
+    @pyqtSlot()
+    def build_visual_prompt_threading(self, reference_image, filename=None):
+        """Generate a YOLOE visual prompt without blocking the GUI thread."""
+        with self.loaded_model_config_lock:
+            model_config = self.loaded_model_config
+        if model_config is None or model_config.get("type") != "yoloe":
+            self.new_model_status.emit(
+                self.tr(
+                    "Load a YOLOE model before generating a visual prompt."
+                )
+            )
+            return
+
+        self.new_model_status.emit(
+            self.tr("Generating visual prompt. Please wait...")
+        )
+        self.prediction_started.emit()
+
+        with self.model_execution_thread_lock:
+            try:
+                execution_running = (
+                    self.model_execution_thread is not None
+                    and self.model_execution_thread.isRunning()
+                )
+            except RuntimeError:
+                self.model_execution_thread = None
+                self.model_execution_worker = None
+                execution_running = False
+
+            if execution_running:
+                self.new_model_status.emit(
+                    self.tr(
+                        "Another model is being executed."
+                        " Please wait for it to finish."
+                    )
+                )
+                self.prediction_finished.emit()
+                return
+
+            self.model_execution_thread = QThread()
+            self.model_execution_worker = GenericWorker(
+                self.build_visual_prompt, reference_image, filename
+            )
+            self.model_execution_worker.finished.connect(
+                self.model_execution_thread.quit
+            )
+            self.model_execution_thread.finished.connect(
+                self.on_model_execution_finished
+            )
+            self.model_execution_thread.finished.connect(
+                self.model_execution_thread.deleteLater
+            )
+            self.model_execution_worker.moveToThread(
+                self.model_execution_thread
+            )
+            self.model_execution_thread.started.connect(
+                self.model_execution_worker.run
+            )
+            self.model_execution_thread.start()
+
+    def clear_visual_prompt(self):
+        """Clear the loaded YOLOE VPE when no inference is running."""
+        with self.model_execution_thread_lock:
+            try:
+                execution_running = (
+                    self.model_execution_thread is not None
+                    and self.model_execution_thread.isRunning()
+                )
+            except RuntimeError:
+                execution_running = False
+            if execution_running:
+                self.new_model_status.emit(
+                    self.tr(
+                        "Another model is being executed."
+                        " Please wait for it to finish."
+                    )
+                )
+                return False
+
+            with self.loaded_model_config_lock:
+                model_config = self.loaded_model_config
+            if model_config is None or model_config.get("type") != "yoloe":
+                return False
+            model_config["model"].clear_visual_prompt()
+
+        status = self.get_visual_prompt_status()
+        self.visual_prompt_status_changed.emit(status)
+        self.new_model_status.emit(self.tr("Visual prompt cleared."))
+        return True
+
+    def save_visual_prompt_profile(self, name, directory):
+        """Save the loaded YOLOE visual prompt profile."""
+        with self.loaded_model_config_lock:
+            model_config = self.loaded_model_config
+        if model_config is None or model_config.get("type") != "yoloe":
+            self.new_model_status.emit(
+                self.tr("Load a YOLOE model before saving a visual prompt.")
+            )
+            return None
+        try:
+            metadata_path = model_config["model"].save_visual_prompt_profile(
+                name, directory
+            )
+            self.visual_prompt_status_changed.emit(
+                self.get_visual_prompt_status()
+            )
+            self.new_model_status.emit(
+                self.tr("Visual prompt profile saved: {path}").format(
+                    path=metadata_path
+                )
+            )
+            return metadata_path
+        except Exception as e:  # noqa
+            logger.error(f"Error in save_visual_prompt_profile: {e}")
+            self.new_model_status.emit(
+                self.tr("Error saving visual prompt profile: {error}").format(
+                    error=str(e)
+                )
+            )
+            return None
+
+    def load_visual_prompt_profile(self, path):
+        """Load a profile in the model execution worker."""
+        with self.loaded_model_config_lock:
+            model_config = self.loaded_model_config
+        if model_config is None or model_config.get("type") != "yoloe":
+            self.new_model_status.emit(
+                self.tr("Load a YOLOE model before loading a visual prompt.")
+            )
+            self.prediction_finished.emit()
+            return
+        try:
+            profile = model_config["model"].load_visual_prompt_profile(path)
+            status = self.get_visual_prompt_status()
+            self.visual_prompt_status_changed.emit(status)
+            self.new_model_status.emit(
+                self.tr(
+                    "Visual prompt profile loaded: {name}; "
+                    "VPE shape: {shape}."
+                ).format(name=profile.name, shape=tuple(profile.vpe.shape))
+            )
+        except Exception as e:  # noqa
+            logger.error(f"Error in load_visual_prompt_profile: {e}")
+            self.new_model_status.emit(
+                self.tr("Error loading visual prompt profile: {error}").format(
+                    error=str(e)
+                )
+            )
+            self.visual_prompt_status_changed.emit(
+                self.get_visual_prompt_status()
+            )
+        self.prediction_finished.emit()
+
+    @pyqtSlot()
+    def load_visual_prompt_profile_threading(self, path):
+        """Restore a profile without blocking the GUI thread."""
+        with self.loaded_model_config_lock:
+            model_config = self.loaded_model_config
+        if model_config is None or model_config.get("type") != "yoloe":
+            self.new_model_status.emit(
+                self.tr("Load a YOLOE model before loading a visual prompt.")
+            )
+            return
+
+        self.new_model_status.emit(
+            self.tr("Loading visual prompt profile. Please wait...")
+        )
+        self.prediction_started.emit()
+        with self.model_execution_thread_lock:
+            try:
+                execution_running = (
+                    self.model_execution_thread is not None
+                    and self.model_execution_thread.isRunning()
+                )
+            except RuntimeError:
+                self.model_execution_thread = None
+                self.model_execution_worker = None
+                execution_running = False
+            if execution_running:
+                self.new_model_status.emit(
+                    self.tr(
+                        "Another model is being executed."
+                        " Please wait for it to finish."
+                    )
+                )
+                self.prediction_finished.emit()
+                return
+
+            self.model_execution_thread = QThread()
+            self.model_execution_worker = GenericWorker(
+                self.load_visual_prompt_profile, path
+            )
+            self.model_execution_worker.finished.connect(
+                self.model_execution_thread.quit
+            )
+            self.model_execution_thread.finished.connect(
+                self.on_model_execution_finished
+            )
+            self.model_execution_thread.finished.connect(
+                self.model_execution_thread.deleteLater
+            )
+            self.model_execution_worker.moveToThread(
+                self.model_execution_thread
+            )
+            self.model_execution_thread.started.connect(
+                self.model_execution_worker.run
+            )
+            self.model_execution_thread.start()
 
     def set_auto_labeling_api_token(self, token):
         """Set the API token for the model"""
@@ -2433,6 +2712,7 @@ class ModelManager(QObject):
         run_tracker=False,
         batch=False,
         existing_shapes=None,
+        visual_prompt=False,
     ):
         """Predict shapes.
         NOTE: This function is blocking. The model can take a long time to
@@ -2448,7 +2728,18 @@ class ModelManager(QObject):
             return
 
         try:
-            if text_prompt is not None:
+            if visual_prompt:
+                if (
+                    model_config.get("type") != "yoloe"
+                    or not model_config["model"].has_visual_prompt()
+                ):
+                    raise RuntimeError(
+                        "No current YOLOE visual prompt is ready."
+                    )
+                auto_labeling_result = model_config["model"].predict_shapes(
+                    image, filename, use_visual_prompt=True
+                )
+            elif text_prompt is not None:
                 auto_labeling_result = model_config["model"].predict_shapes(
                     image, filename, text_prompt=text_prompt
                 )
@@ -2482,6 +2773,9 @@ class ModelManager(QObject):
             translated_template = self.tr(template)
             error_text = translated_template.format(error_message=str(e))
             self.new_model_status.emit(error_text)
+            if batch:
+                self.prediction_finished.emit()
+                raise
 
         self.prediction_finished.emit()
 

--- a/anylabeling/services/auto_labeling/visual_prompt_profile.py
+++ b/anylabeling/services/auto_labeling/visual_prompt_profile.py
@@ -1,0 +1,444 @@
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import numpy as np
+
+PROFILE_VERSION = 1
+METADATA_FILENAME = "metadata.json"
+EMBEDDING_FILENAME = "embedding.npz"
+MAX_EMBEDDING_FILE_SIZE = 64 * 1024 * 1024
+
+
+class VisualPromptProfileError(ValueError):
+    """Raised when a visual prompt profile is invalid or corrupted."""
+
+
+class VisualPromptCompatibilityError(VisualPromptProfileError):
+    """Raised when a profile cannot be used by the current model."""
+
+
+def _sha256(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as file:
+        for chunk in iter(lambda: file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _validate_name(name):
+    if not isinstance(name, str) or not name.strip():
+        raise VisualPromptProfileError("Profile name must not be empty.")
+    name = name.strip()
+    if len(name) > 128:
+        raise VisualPromptProfileError(
+            "Profile name must contain at most 128 characters."
+        )
+    if any(ord(character) < 32 for character in name):
+        raise VisualPromptProfileError(
+            "Profile name must not contain control characters."
+        )
+    if any(character in '<>:"/\\|?*' for character in name):
+        raise VisualPromptProfileError(
+            "Profile name contains characters that are invalid in a path."
+        )
+    return name
+
+
+def _validate_json_value(value, path="metadata"):
+    if value is None or isinstance(value, (str, bool, int)):
+        return
+    if isinstance(value, float):
+        if not np.isfinite(value):
+            raise VisualPromptProfileError(
+                f"{path} contains a non-finite number."
+            )
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            _validate_json_value(item, f"{path}[{index}]")
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise VisualPromptProfileError(
+                    f"{path} contains a non-string key."
+                )
+            _validate_json_value(item, f"{path}.{key}")
+        return
+    raise VisualPromptProfileError(
+        f"{path} contains an unsupported value: {type(value).__name__}."
+    )
+
+
+def _validate_created_at(created_at):
+    try:
+        parsed_time = datetime.fromisoformat(created_at.replace("Z", "+00:00"))
+    except (AttributeError, TypeError, ValueError) as error:
+        raise VisualPromptProfileError(
+            "Profile created_at must be a valid ISO 8601 timestamp."
+        ) from error
+    if parsed_time.tzinfo is None:
+        raise VisualPromptProfileError(
+            "Profile created_at must include a timezone."
+        )
+
+
+def _validate_model_signature(model_signature):
+    required = {
+        "model_type": str,
+        "model_path": str,
+        "model_file": str,
+        "model_size": int,
+        "architecture": str,
+        "embedding_dimension": int,
+    }
+    if not isinstance(model_signature, dict):
+        raise VisualPromptProfileError(
+            "Profile model_signature must be an object."
+        )
+    for key, expected_type in required.items():
+        value = model_signature.get(key)
+        if isinstance(value, bool) or not isinstance(value, expected_type):
+            raise VisualPromptProfileError(
+                f"Profile model_signature.{key} is invalid."
+            )
+    _validate_json_value(model_signature, "model_signature")
+
+
+def _validate_reference(reference):
+    if not isinstance(reference, dict):
+        raise VisualPromptProfileError(
+            "Profile reference metadata must be an object."
+        )
+    if "image_path" not in reference or (
+        reference["image_path"] is not None
+        and (
+            not isinstance(reference["image_path"], str)
+            or not reference["image_path"].strip()
+        )
+    ):
+        raise VisualPromptProfileError(
+            "Profile reference image path is invalid."
+        )
+    boxes = reference.get("boxes")
+    if not isinstance(boxes, list) or not boxes:
+        raise VisualPromptProfileError(
+            "Profile reference boxes must not be empty."
+        )
+    boxes_array = np.asarray(boxes, dtype=np.float64)
+    if (
+        boxes_array.ndim != 2
+        or boxes_array.shape[1] != 4
+        or not np.isfinite(boxes_array).all()
+        or np.any(boxes_array[:, 2:] <= boxes_array[:, :2])
+    ):
+        raise VisualPromptProfileError(
+            "Profile reference boxes must be valid xyxy boxes."
+        )
+    image_size = reference.get("image_size")
+    valid_size = (
+        isinstance(image_size, list)
+        and len(image_size) == 2
+        and all(
+            not isinstance(value, bool)
+            and isinstance(value, (int, float))
+            and np.isfinite(value)
+            and value > 0
+            for value in image_size
+        )
+    )
+    boxes_in_bounds = valid_size and (
+        np.all(boxes_array[:, :2] >= 0)
+        and np.all(boxes_array[:, 2] <= image_size[0])
+        and np.all(boxes_array[:, 3] <= image_size[1])
+    )
+    if not boxes_in_bounds:
+        raise VisualPromptProfileError(
+            "Profile reference boxes exceed the reference image."
+        )
+    instance_count = reference.get("instance_count")
+    if instance_count is not None and instance_count != len(boxes):
+        raise VisualPromptProfileError(
+            "Profile reference instance count does not match its boxes."
+        )
+    _validate_json_value(reference, "reference")
+
+
+def _validate_classes(classes):
+    if (
+        not isinstance(classes, list)
+        or not classes
+        or any(
+            not isinstance(item, str) or not item.strip() for item in classes
+        )
+    ):
+        raise VisualPromptProfileError(
+            "Profile classes must be non-empty strings."
+        )
+
+
+def _validate_vpe(vpe, classes, embedding_dimension):
+    if not isinstance(vpe, np.ndarray):
+        raise VisualPromptProfileError(
+            "Profile embedding must be a NumPy array."
+        )
+    if vpe.dtype != np.float32:
+        raise VisualPromptProfileError(
+            "Profile embedding dtype must be float32."
+        )
+    if (
+        vpe.ndim != 3
+        or vpe.shape[0] != 1
+        or vpe.shape[1] != len(classes)
+        or vpe.shape[2] != embedding_dimension
+    ):
+        raise VisualPromptProfileError(
+            "Profile embedding shape is inconsistent with its metadata."
+        )
+    if not np.isfinite(vpe).all():
+        raise VisualPromptProfileError(
+            "Profile embedding contains non-finite values."
+        )
+
+
+@dataclass(frozen=True)
+class VisualPromptProfile:
+    """Portable YOLOE visual prompt metadata and embedding."""
+
+    name: str
+    created_at: str
+    model_name: str
+    model_signature: dict
+    reference: dict
+    classes: list
+    vpe: np.ndarray
+    version: int = PROFILE_VERSION
+
+    def validate(self):
+        name = _validate_name(self.name)
+        if isinstance(self.version, bool) or self.version != PROFILE_VERSION:
+            raise VisualPromptProfileError(
+                "Unsupported visual prompt profile version: "
+                f"{self.version}; expected {PROFILE_VERSION}."
+            )
+        _validate_created_at(self.created_at)
+        if not isinstance(self.model_name, str) or not self.model_name.strip():
+            raise VisualPromptProfileError("Profile model_name is missing.")
+        _validate_model_signature(self.model_signature)
+        _validate_reference(self.reference)
+        _validate_classes(self.classes)
+        reference_classes = self.reference.get("classes")
+        if reference_classes is not None and reference_classes != self.classes:
+            raise VisualPromptProfileError(
+                "Profile classes do not match its reference metadata."
+            )
+        _validate_vpe(
+            self.vpe,
+            self.classes,
+            self.model_signature["embedding_dimension"],
+        )
+        return name
+
+    def to_metadata(self, embedding_sha256):
+        name = self.validate()
+        return {
+            "version": self.version,
+            "name": name,
+            "created_at": self.created_at,
+            "model_name": self.model_name,
+            "model_signature": self.model_signature,
+            "reference": self.reference,
+            "classes": self.classes,
+            "vpe_shape": list(self.vpe.shape),
+            "vpe_dtype": str(self.vpe.dtype),
+            "embedding_file": EMBEDDING_FILENAME,
+            "embedding_sha256": embedding_sha256,
+        }
+
+    def save(self, directory):
+        """Atomically write embedding first and metadata as commit marker."""
+        self.validate()
+        directory = os.path.abspath(os.fspath(directory))
+        os.makedirs(directory, exist_ok=True)
+        embedding_path = os.path.join(directory, EMBEDDING_FILENAME)
+        metadata_path = os.path.join(directory, METADATA_FILENAME)
+        embedding_temp = None
+        metadata_temp = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="wb", suffix=".npz", dir=directory, delete=False
+            ) as file:
+                embedding_temp = file.name
+                np.savez_compressed(file, vpe=self.vpe)
+            embedding_sha256 = _sha256(embedding_temp)
+            metadata = self.to_metadata(embedding_sha256)
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                suffix=".json",
+                dir=directory,
+                encoding="utf-8",
+                delete=False,
+            ) as file:
+                metadata_temp = file.name
+                json.dump(metadata, file, ensure_ascii=False, indent=2)
+                file.write("\n")
+            os.replace(embedding_temp, embedding_path)
+            embedding_temp = None
+            os.replace(metadata_temp, metadata_path)
+            metadata_temp = None
+        finally:
+            for path in (embedding_temp, metadata_temp):
+                if path and os.path.exists(path):
+                    os.unlink(path)
+        return metadata_path
+
+    @classmethod
+    def create(
+        cls, name, model_name, model_signature, reference, classes, vpe
+    ):
+        created_at = (
+            datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+        )
+        return cls(
+            name=name,
+            created_at=created_at,
+            model_name=model_name,
+            model_signature=dict(model_signature),
+            reference=dict(reference),
+            classes=list(classes),
+            vpe=np.asarray(vpe, dtype=np.float32),
+        )
+
+    @classmethod
+    def load(cls, path):
+        path = os.path.abspath(os.fspath(path))
+        metadata_path = (
+            os.path.join(path, METADATA_FILENAME)
+            if os.path.isdir(path)
+            else path
+        )
+        if not os.path.isfile(metadata_path):
+            raise VisualPromptProfileError(
+                f"Visual prompt metadata does not exist: {metadata_path}"
+            )
+        try:
+            with open(metadata_path, encoding="utf-8") as file:
+                metadata = json.load(file)
+        except (OSError, UnicodeError, json.JSONDecodeError) as error:
+            raise VisualPromptProfileError(
+                f"Could not read visual prompt metadata: {error}"
+            ) from error
+        if not isinstance(metadata, dict):
+            raise VisualPromptProfileError(
+                "Visual prompt metadata must contain a JSON object."
+            )
+        required_keys = {
+            "version",
+            "name",
+            "created_at",
+            "model_name",
+            "model_signature",
+            "reference",
+            "classes",
+            "vpe_shape",
+            "vpe_dtype",
+            "embedding_file",
+            "embedding_sha256",
+        }
+        missing = sorted(required_keys - metadata.keys())
+        if missing:
+            raise VisualPromptProfileError(
+                "Visual prompt metadata is missing: " + ", ".join(missing)
+            )
+        if metadata["version"] != PROFILE_VERSION:
+            raise VisualPromptProfileError(
+                "Unsupported visual prompt profile version: "
+                f"{metadata['version']}; expected {PROFILE_VERSION}."
+            )
+        if metadata["embedding_file"] != EMBEDDING_FILENAME:
+            raise VisualPromptProfileError(
+                "Visual prompt embedding filename is invalid."
+            )
+        embedding_path = os.path.join(
+            os.path.dirname(metadata_path), EMBEDDING_FILENAME
+        )
+        if not os.path.isfile(embedding_path):
+            raise VisualPromptProfileError(
+                f"Visual prompt embedding does not exist: {embedding_path}"
+            )
+        if os.path.getsize(embedding_path) > MAX_EMBEDDING_FILE_SIZE:
+            raise VisualPromptProfileError(
+                "Visual prompt embedding file is unexpectedly large."
+            )
+        checksum = metadata["embedding_sha256"]
+        if (
+            not isinstance(checksum, str)
+            or len(checksum) != 64
+            or _sha256(embedding_path) != checksum.lower()
+        ):
+            raise VisualPromptProfileError(
+                "Visual prompt embedding checksum is invalid."
+            )
+        try:
+            with np.load(embedding_path, allow_pickle=False) as archive:
+                if archive.files != ["vpe"]:
+                    raise VisualPromptProfileError(
+                        "Visual prompt embedding archive is invalid."
+                    )
+                vpe = archive["vpe"].copy()
+        except VisualPromptProfileError:
+            raise
+        except (OSError, ValueError, KeyError) as error:
+            raise VisualPromptProfileError(
+                f"Could not read visual prompt embedding: {error}"
+            ) from error
+        if metadata["vpe_shape"] != list(vpe.shape):
+            raise VisualPromptProfileError(
+                "Visual prompt embedding shape does not match metadata."
+            )
+        if metadata["vpe_dtype"] != str(vpe.dtype):
+            raise VisualPromptProfileError(
+                "Visual prompt embedding dtype does not match metadata."
+            )
+        profile = cls(
+            name=metadata["name"],
+            created_at=metadata["created_at"],
+            model_name=metadata["model_name"],
+            model_signature=metadata["model_signature"],
+            reference=metadata["reference"],
+            classes=metadata["classes"],
+            vpe=vpe,
+            version=metadata["version"],
+        )
+        profile.validate()
+        return profile
+
+    def validate_compatibility(self, current_signature):
+        """Require the current YOLOE architecture and weights to match."""
+        keys = (
+            "model_type",
+            "model_file",
+            "model_size",
+            "architecture",
+            "embedding_dimension",
+        )
+        mismatches = [
+            key
+            for key in keys
+            if self.model_signature.get(key) != current_signature.get(key)
+        ]
+        if mismatches:
+            details = ", ".join(
+                f"{key}: {self.model_signature.get(key)!r} != "
+                f"{current_signature.get(key)!r}"
+                for key in mismatches
+            )
+            raise VisualPromptCompatibilityError(
+                "This visual prompt is incompatible with the current model "
+                f"({details}). Regenerate it from the saved reference."
+            )
+        return True

--- a/anylabeling/services/auto_labeling/yoloe.py
+++ b/anylabeling/services/auto_labeling/yoloe.py
@@ -1,4 +1,6 @@
 import os
+from enum import Enum
+
 import numpy as np
 from PIL import Image
 
@@ -9,6 +11,7 @@ from anylabeling.views.labeling.shape import Shape
 from anylabeling.views.labeling.logger import logger
 from .model import Model
 from .types import AutoLabelingResult
+from .visual_prompt_profile import VisualPromptProfile
 
 try:
     import torch
@@ -46,6 +49,14 @@ class _MobileCLIPTextEncoder:
         return text_features / text_features.norm(p=2, dim=-1, keepdim=True)
 
 
+class VisualPromptState(str, Enum):
+    """Lifecycle states for YOLOE cross-image visual prompts."""
+
+    NO_VISUAL_PROMPT = "NO_VISUAL_PROMPT"
+    REFERENCE_MARKS_READY = "REFERENCE_MARKS_READY"
+    VISUAL_PROMPT_READY = "VISUAL_PROMPT_READY"
+
+
 class YOLOE(Model):
     """YOLOE: Real-Time Seeing Anything Model"""
 
@@ -71,6 +82,11 @@ class YOLOE(Model):
             "toggle_preserve_existing_annotations",
             "button_add_rect",
             "button_clear",
+            "button_generate_visual_prompt",
+            "visual_prompt_status_label",
+            "button_save_visual_prompt",
+            "button_load_visual_prompt",
+            "button_clear_visual_prompt",
         ]
         output_modes = {
             "rectangle": QCoreApplication.translate("Model", "Rectangle"),
@@ -109,8 +125,18 @@ class YOLOE(Model):
         # Lazy-load model instances for different task modes
         self._text_model = None
         self._visual_model = None
+        self._cross_image_visual_model = None
         self._prompt_free_model = None
         self._text_encoder = None
+
+        # Cross-image visual prompt state. This is deliberately independent
+        # from the one-shot marks used by the existing intra-image mode.
+        self.visual_prompt_vpe = None
+        self.visual_prompt_classes = []
+        self.visual_prompt_reference = None
+        self.visual_prompt_model_signature = None
+        self.visual_prompt_profile_name = None
+        self.visual_prompt_state = VisualPromptState.NO_VISUAL_PROMPT
 
         # Cache text prompt state to avoid unnecessary model rebuilds
         self._current_text_prompt = None
@@ -168,6 +194,12 @@ class YOLOE(Model):
     def set_auto_labeling_marks(self, marks):
         """Set visual prompting marks"""
         self.marks = marks
+        if marks:
+            self.visual_prompt_state = VisualPromptState.REFERENCE_MARKS_READY
+        elif self.has_visual_prompt():
+            self.visual_prompt_state = VisualPromptState.VISUAL_PROMPT_READY
+        else:
+            self.visual_prompt_state = VisualPromptState.NO_VISUAL_PROMPT
 
     def set_auto_labeling_iou(self, value):
         """Set IoU threshold for auto labeling"""
@@ -251,6 +283,314 @@ class YOLOE(Model):
             self._visual_model = self.build_model(self.config["model_path"])
         return self._visual_model
 
+    def _get_cross_image_visual_model(self):
+        """Get the model reserved for cached cross-image visual prompts."""
+        if self._cross_image_visual_model is None:
+            self._cross_image_visual_model = self.build_model(
+                self.config["model_path"]
+            )
+        return self._cross_image_visual_model
+
+    @staticmethod
+    def validate_reference_boxes(boxes, image_size):
+        """Validate and normalize reference boxes in xyxy pixel format."""
+        boxes = np.asarray(boxes, dtype=np.float32)
+        if boxes.ndim != 2 or boxes.shape[0] == 0 or boxes.shape[1] != 4:
+            raise ValueError("Reference boxes must have shape [N, 4].")
+        if not np.isfinite(boxes).all():
+            raise ValueError("Reference boxes must contain finite values.")
+
+        width, height = image_size
+        invalid = (
+            (boxes[:, 0] < 0)
+            | (boxes[:, 1] < 0)
+            | (boxes[:, 2] > width)
+            | (boxes[:, 3] > height)
+            | (boxes[:, 2] <= boxes[:, 0])
+            | (boxes[:, 3] <= boxes[:, 1])
+        )
+        if invalid.any():
+            raise ValueError(
+                "Reference boxes must be valid and within image bounds."
+            )
+        return boxes
+
+    @staticmethod
+    def _normalize_visual_prompt_classes(classes):
+        if isinstance(classes, str):
+            raise TypeError(
+                "Visual prompt classes must be a sequence of names."
+            )
+        classes = ["object"] if classes is None else list(classes)
+        if not classes or any(
+            not isinstance(name, str) or not name.strip() for name in classes
+        ):
+            raise ValueError(
+                "Visual prompt classes must be non-empty strings."
+            )
+        return [name.strip() for name in classes]
+
+    @staticmethod
+    def _get_model_device(model):
+        return next(model.model.parameters()).device
+
+    @staticmethod
+    def _get_model_embedding_dimension(model):
+        head = model.model.model[-1]
+        embed = getattr(head, "embed", None)
+        return int(embed) if isinstance(embed, (int, np.integer)) else None
+
+    def _make_visual_prompt_model_signature(self, model, vpe):
+        model_path = os.path.abspath(self.config["model_path"])
+        return {
+            "model_type": self.config["type"],
+            "model_name": self.config["name"],
+            "model_path": model_path,
+            "model_file": os.path.basename(model_path),
+            "model_size": os.path.getsize(model_path),
+            "architecture": type(model.model).__name__,
+            "embedding_dimension": int(vpe.shape[-1]),
+        }
+
+    def _boxes_from_marks(self):
+        if not self.marks:
+            raise ValueError("No reference bounding boxes are available.")
+
+        boxes = []
+        for mark in self.marks:
+            if mark.get("type") != "rectangle":
+                raise ValueError(
+                    "Cross-image visual prompts only support rectangles."
+                )
+            data = mark.get("data")
+            if (
+                not isinstance(data, (list, tuple, np.ndarray))
+                or len(data) != 4
+            ):
+                raise ValueError("Each reference rectangle must contain xyxy.")
+            boxes.append(data)
+        return boxes
+
+    def build_visual_prompt(
+        self,
+        reference_image,
+        reference_boxes=None,
+        classes=None,
+    ):
+        """Generate and cache a VPE from one reference image."""
+        classes = self._normalize_visual_prompt_classes(classes)
+        if len(classes) != 1:
+            raise ValueError(
+                "The current cross-image MVP supports one visual class."
+            )
+
+        reference_path = None
+        if isinstance(reference_image, (str, os.PathLike)):
+            reference_path = os.path.abspath(os.fspath(reference_image))
+            if not os.path.isfile(reference_path):
+                raise FileNotFoundError(
+                    f"Reference image does not exist: {reference_path}"
+                )
+            with Image.open(reference_path) as opened_image:
+                image = opened_image.convert("RGB")
+        elif isinstance(reference_image, Image.Image):
+            image = reference_image.convert("RGB")
+        else:
+            raise TypeError("Reference image must be a path or PIL image.")
+
+        if reference_boxes is None:
+            reference_boxes = self._boxes_from_marks()
+        boxes = self.validate_reference_boxes(reference_boxes, image.size)
+        prompts = {
+            "bboxes": boxes,
+            "cls": np.zeros(len(boxes), dtype=np.int64),
+        }
+
+        model = self._get_cross_image_visual_model()
+        previous_vpe = self.visual_prompt_vpe
+        previous_classes = self.visual_prompt_classes
+        try:
+            # Ultralytics only honors the predictor argument when no predictor
+            # is already attached. A prior target prediction installs the
+            # standard predictor, so generation must always reset it first.
+            model.predictor = None
+            model.predict(
+                source=image,
+                imgsz=self.input_shape,
+                conf=self.conf_thres,
+                iou=self.iou_thres,
+                verbose=False,
+                prompts=prompts,
+                predictor=YOLOEVPSegPredictor,
+                return_vpe=True,
+            )
+            predictor = model.predictor
+            if predictor is None or not hasattr(predictor, "vpe"):
+                raise RuntimeError("YOLOE did not return a visual embedding.")
+            vpe = predictor.vpe
+            reference = {
+                "image_path": reference_path,
+                "image_size": list(image.size),
+                "boxes": boxes.tolist(),
+                "instance_count": len(boxes),
+                "classes": classes,
+            }
+            self.set_visual_prompt(vpe, classes, reference)
+            self.marks = []
+            logger.info(
+                "Cross-image visual prompt generated: "
+                f"classes={classes}, instances={len(boxes)}, "
+                f"vpe_shape={tuple(self.visual_prompt_vpe.shape)}"
+            )
+            return self.visual_prompt_vpe
+        except Exception:
+            model.predictor = None
+            if previous_vpe is not None and previous_classes:
+                model.set_classes(previous_classes, previous_vpe)
+            raise
+
+    def set_visual_prompt(self, vpe, classes=None, reference=None):
+        """Validate a VPE and bind it to the cross-image model."""
+        classes = self._normalize_visual_prompt_classes(classes)
+        model = self._get_cross_image_visual_model()
+        device = self._get_model_device(model)
+        if isinstance(vpe, np.ndarray):
+            vpe = torch.from_numpy(vpe)
+        if not isinstance(vpe, torch.Tensor):
+            raise TypeError(
+                "Visual prompt embedding must be a tensor or array."
+            )
+        if vpe.ndim != 3 or vpe.shape[0] != 1:
+            raise ValueError(
+                "Visual prompt embedding must have shape [1, C, D]."
+            )
+        if vpe.shape[1] != len(classes):
+            raise ValueError(
+                "Visual prompt class count does not match the embedding."
+            )
+        expected_dimension = self._get_model_embedding_dimension(model)
+        if (
+            expected_dimension is not None
+            and vpe.shape[-1] != expected_dimension
+        ):
+            raise ValueError(
+                "Visual prompt embedding dimension is incompatible with "
+                f"the model ({vpe.shape[-1]} != {expected_dimension})."
+            )
+        if not torch.isfinite(vpe).all().item():
+            raise ValueError(
+                "Visual prompt embedding must contain finite values."
+            )
+
+        cached_vpe = (
+            vpe.detach().to(device=device, dtype=torch.float32).clone()
+        )
+        model.set_classes(classes, cached_vpe)
+        # VPE encoding is complete. Target images require the ordinary
+        # segmentation predictor, which is created lazily on first inference.
+        model.predictor = None
+
+        self.visual_prompt_vpe = cached_vpe
+        self.visual_prompt_classes = classes
+        self.visual_prompt_reference = reference
+        self.visual_prompt_model_signature = (
+            self._make_visual_prompt_model_signature(model, cached_vpe)
+        )
+        self.visual_prompt_profile_name = None
+        self.visual_prompt_state = VisualPromptState.VISUAL_PROMPT_READY
+
+    def save_visual_prompt_profile(self, name, directory):
+        """Save the cached VPE as a portable, non-pickle profile."""
+        if not self.has_visual_prompt():
+            raise RuntimeError("No visual prompt is ready to save.")
+        profile = VisualPromptProfile.create(
+            name=name,
+            model_name=self.config["name"],
+            model_signature=self.visual_prompt_model_signature,
+            reference=self.visual_prompt_reference or {},
+            classes=self.visual_prompt_classes,
+            vpe=(
+                self.visual_prompt_vpe.detach()
+                .cpu()
+                .to(dtype=torch.float32)
+                .numpy()
+            ),
+        )
+        metadata_path = profile.save(directory)
+        self.visual_prompt_profile_name = profile.name.strip()
+        logger.info(
+            "Visual prompt profile saved: "
+            f"name={self.visual_prompt_profile_name}, "
+            f"path={metadata_path}"
+        )
+        return metadata_path
+
+    def load_visual_prompt_profile(self, path):
+        """Validate a profile and restore its VPE to the model device."""
+        profile = VisualPromptProfile.load(path)
+        model = self._get_cross_image_visual_model()
+        current_signature = self._make_visual_prompt_model_signature(
+            model, profile.vpe
+        )
+        profile.validate_compatibility(current_signature)
+        self.set_visual_prompt(
+            profile.vpe,
+            classes=profile.classes,
+            reference=profile.reference,
+        )
+        self.visual_prompt_profile_name = profile.name
+        logger.info(
+            "Visual prompt profile loaded: "
+            f"name={profile.name}, device={self.visual_prompt_vpe.device}, "
+            f"vpe_shape={tuple(self.visual_prompt_vpe.shape)}"
+        )
+        return profile
+
+    def clear_visual_prompt(self):
+        """Clear cached VPE state without affecting other YOLOE modes."""
+        if self._cross_image_visual_model is not None:
+            self._cross_image_visual_model.predictor = None
+        self._cross_image_visual_model = None
+        self.visual_prompt_vpe = None
+        self.visual_prompt_classes = []
+        self.visual_prompt_reference = None
+        self.visual_prompt_model_signature = None
+        self.visual_prompt_profile_name = None
+        self.visual_prompt_state = VisualPromptState.NO_VISUAL_PROMPT
+        self.marks = []
+
+    def has_visual_prompt(self):
+        """Return whether a validated cross-image VPE is cached."""
+        return bool(
+            self.visual_prompt_vpe is not None and self.visual_prompt_classes
+        )
+
+    @property
+    def visual_prompt_ready(self):
+        return self.has_visual_prompt()
+
+    def get_visual_prompt_state(self):
+        return self.visual_prompt_state.value
+
+    def predict_with_visual_prompt(self, target_image):
+        """Predict one target using the cached cross-image visual prompt."""
+        if not self.has_visual_prompt():
+            raise RuntimeError("No cross-image visual prompt is ready.")
+
+        model = self._get_cross_image_visual_model()
+        if isinstance(model.predictor, YOLOEVPSegPredictor):
+            model.predictor = None
+        results = model.predict(
+            source=target_image,
+            imgsz=self.input_shape,
+            conf=self.conf_thres,
+            iou=self.iou_thres,
+            verbose=False,
+        )
+        self.visual_prompt_state = VisualPromptState.VISUAL_PROMPT_READY
+        shapes = self.postprocess(results)
+        return AutoLabelingResult(shapes, replace=self.replace)
+
     def _get_prompt_free_model(self):
         """Get or create prompt-free model instance"""
         if (
@@ -274,20 +614,30 @@ class YOLOE(Model):
         self._prompt_free_model.model.model[-1].conf = self.conf_thres
         return self._prompt_free_model
 
-    def predict_shapes(self, image, image_path=None, text_prompt=None):
+    def predict_shapes(
+        self,
+        image,
+        image_path=None,
+        text_prompt=None,
+        use_visual_prompt=False,
+    ):
         """Predict shapes from image using different prompting modes"""
 
         if image is None:
             return []
 
         try:
-            image = Image.open(image_path)
+            with Image.open(image_path) as opened_image:
+                image = opened_image.convert("RGB")
         except Exception as e:  # noqa
-            logger.warning("Could not inference model")
-            logger.warning(e)
-            return []
+            raise RuntimeError(
+                f"Could not read target image '{image_path}': {e}"
+            ) from e
 
         kwargs = {}
+
+        if use_visual_prompt:
+            return self.predict_with_visual_prompt(image)
 
         # Visual prompting mode
         if self.marks:
@@ -309,7 +659,7 @@ class YOLOE(Model):
                 verbose=False,
                 **kwargs,
             )
-            self.marks = []
+            self.set_auto_labeling_marks([])
 
         # Text prompting mode
         elif text_prompt:
@@ -337,6 +687,10 @@ class YOLOE(Model):
                 verbose=False,
                 **kwargs,
             )
+
+        # Cached cross-image visual prompting mode
+        elif self.has_visual_prompt():
+            return self.predict_with_visual_prompt(image)
 
         # Prompt-free mode
         else:
@@ -367,11 +721,8 @@ class YOLOE(Model):
 
     def unload(self):
         """Clean up model instances"""
-        if self._text_model:
-            del self._text_model
-        if self._visual_model:
-            del self._visual_model
-        if self._prompt_free_model:
-            del self._prompt_free_model
-        if self._text_encoder:
-            del self._text_encoder
+        self.clear_visual_prompt()
+        self._text_model = None
+        self._visual_model = None
+        self._prompt_free_model = None
+        self._text_encoder = None

--- a/anylabeling/views/labeling/utils/batch.py
+++ b/anylabeling/views/labeling/utils/batch.py
@@ -11,6 +11,7 @@ from PyQt6.QtWidgets import (
     QDialog,
     QLabel,
     QLineEdit,
+    QComboBox,
     QDialogButtonBox,
     QApplication,
 )
@@ -24,6 +25,7 @@ from anylabeling.services.auto_labeling import (
     _BATCH_PROCESSING_VIDEO_MODELS,
     _SKIP_DET_MODELS,
 )
+from anylabeling.services.auto_labeling.types import AutoLabelingResult
 from anylabeling.views.labeling.logger import logger
 from anylabeling.views.labeling.schema import IMAGE_TAGS_FIELD
 from anylabeling.views.labeling.shape import Shape
@@ -140,6 +142,63 @@ class TextInputDialog(QDialog):
         return ""
 
 
+class YoloeBatchPromptDialog(QDialog):
+    """Select the explicit prompt source for a YOLOE batch run."""
+
+    VISUAL_PROMPT = "visual_prompt"
+    TEXT_PROMPT = "text_prompt"
+    PROMPT_FREE = "prompt_free"
+
+    def __init__(self, visual_prompt_ready, parent=None):
+        super().__init__(parent)
+        self.setWindowTitle(self.tr("YOLOE Batch Prompt"))
+        self.setFixedSize(440, 210)
+
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(24, 24, 24, 24)
+        layout.setSpacing(12)
+        layout.addWidget(QLabel(self.tr("Select the prompt for this batch:")))
+
+        self.mode_combo = QComboBox()
+        if visual_prompt_ready:
+            self.mode_combo.addItem(
+                self.tr("Current Visual Prompt"), self.VISUAL_PROMPT
+            )
+        self.mode_combo.addItem(self.tr("Text Prompt"), self.TEXT_PROMPT)
+        self.mode_combo.addItem(self.tr("Prompt-Free"), self.PROMPT_FREE)
+        layout.addWidget(self.mode_combo)
+
+        self.text_input = QLineEdit()
+        self.text_input.setPlaceholderText(
+            self.tr("Enter text prompt, e.g. person.car")
+        )
+        layout.addWidget(self.text_input)
+
+        button_box = QDialogButtonBox(
+            QDialogButtonBox.StandardButton.Ok
+            | QDialogButtonBox.StandardButton.Cancel
+        )
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        layout.addWidget(button_box)
+        self.mode_combo.currentIndexChanged.connect(self._update_text_input)
+        self._update_text_input()
+
+    def _update_text_input(self):
+        self.text_input.setEnabled(
+            self.mode_combo.currentData() == self.TEXT_PROMPT
+        )
+
+    def get_selection(self):
+        if self.exec() != QDialog.DialogCode.Accepted:
+            return None
+        mode = self.mode_combo.currentData()
+        text = self.text_input.text().strip()
+        if mode == self.TEXT_PROMPT and not text:
+            return None
+        return mode, text
+
+
 def get_image_size(image_path):
     with Image.open(image_path) as img:
         return img.size
@@ -183,7 +242,9 @@ def load_existing_shapes(image_file):
         return None
 
 
-def finish_processing(self, progress_dialog):
+def finish_processing(
+    self, progress_dialog, failed_image_count=0, cancelled=False
+):
     if not getattr(self, "_batch_processing_active", False):
         progress_dialog.close()
         return
@@ -203,11 +264,19 @@ def finish_processing(self, progress_dialog):
         _reset_batch_processing_state(self)
         progress_dialog.close()
 
-    popup = Popup(
-        self.tr("Processing completed successfully!"),
-        self,
-        icon=new_icon_path("copy-green", "svg"),
-    )
+    if cancelled:
+        message = self.tr("Batch processing cancelled.")
+        icon = new_icon_path("error", "svg")
+    elif failed_image_count:
+        message = self.tr(
+            "Batch processing completed with {count} failed image(s). "
+            "Check the logs for details."
+        ).format(count=failed_image_count)
+        icon = new_icon_path("error", "svg")
+    else:
+        message = self.tr("Processing completed successfully!")
+        icon = new_icon_path("copy-green", "svg")
+    popup = Popup(message, self, icon=icon)
     popup.show_popup(self, position="center")
 
 
@@ -225,6 +294,7 @@ def _reset_batch_processing_state(self):
     for attribute in (
         "text_prompt",
         "run_tracker",
+        "batch_visual_prompt",
         "image_index",
         "current_index",
     ):
@@ -303,17 +373,20 @@ def save_auto_labeling_result(self, image_file, auto_labeling_result):
 
         with io_open(label_file, "w") as f:
             json.dump(data, f, ensure_ascii=False, indent=2)
+        return True
 
     except Exception as e:
         logger.error(
             f"Failed to save auto labeling result for image file '{image_file}': {str(e)}"
         )
+        return False
 
 
 class BatchProcessingThread(QThread):
     progress_updated = pyqtSignal(int, str)
-    processing_finished = pyqtSignal()
+    processing_finished = pyqtSignal(int, bool)
     error_occurred = pyqtSignal(str)
+    image_failed = pyqtSignal(str, str)
 
     def __init__(
         self,
@@ -324,6 +397,7 @@ class BatchProcessingThread(QThread):
         text_prompt,
         run_tracker,
         skip_detection,
+        visual_prompt=False,
     ):
         super().__init__()
         self.app = app
@@ -333,9 +407,11 @@ class BatchProcessingThread(QThread):
         self.text_prompt = text_prompt
         self.run_tracker = run_tracker
         self.skip_detection = skip_detection
+        self.visual_prompt = visual_prompt
 
     def run(self):
         total_images = len(self.image_list)
+        failed_images = []
         try:
             while (
                 self.image_index < total_images
@@ -343,35 +419,57 @@ class BatchProcessingThread(QThread):
             ):
                 image_file = self.image_list[self.image_index]
 
-                if self.text_prompt:
-                    result = self.app.auto_labeling_widget.model_manager.predict_shapes(
-                        self.app.image,
-                        image_file,
-                        text_prompt=self.text_prompt,
-                        batch=True,
-                    )
-                elif self.run_tracker:
-                    result = self.app.auto_labeling_widget.model_manager.predict_shapes(
-                        self.app.image,
-                        image_file,
-                        run_tracker=self.run_tracker,
-                        batch=True,
-                    )
-                else:
-                    existing_shapes = None
-                    if (
-                        self.model_type in _SKIP_DET_MODELS
-                        and self.skip_detection
-                    ):
-                        existing_shapes = load_existing_shapes(image_file)
-                    result = self.app.auto_labeling_widget.model_manager.predict_shapes(
-                        self.app.image,
-                        image_file,
-                        batch=True,
-                        existing_shapes=existing_shapes,
-                    )
+                try:
+                    if self.visual_prompt:
+                        result = self.app.auto_labeling_widget.model_manager.predict_shapes(
+                            self.app.image,
+                            image_file,
+                            batch=True,
+                            visual_prompt=True,
+                        )
+                    elif self.text_prompt:
+                        result = self.app.auto_labeling_widget.model_manager.predict_shapes(
+                            self.app.image,
+                            image_file,
+                            text_prompt=self.text_prompt,
+                            batch=True,
+                        )
+                    elif self.run_tracker:
+                        result = self.app.auto_labeling_widget.model_manager.predict_shapes(
+                            self.app.image,
+                            image_file,
+                            run_tracker=self.run_tracker,
+                            batch=True,
+                        )
+                    else:
+                        existing_shapes = None
+                        if (
+                            self.model_type in _SKIP_DET_MODELS
+                            and self.skip_detection
+                        ):
+                            existing_shapes = load_existing_shapes(image_file)
+                        result = self.app.auto_labeling_widget.model_manager.predict_shapes(
+                            self.app.image,
+                            image_file,
+                            batch=True,
+                            existing_shapes=existing_shapes,
+                        )
 
-                save_auto_labeling_result(self.app, image_file, result)
+                    if not isinstance(result, AutoLabelingResult):
+                        raise RuntimeError(
+                            "Model did not return a valid auto-labeling result."
+                        )
+                    if not save_auto_labeling_result(
+                        self.app, image_file, result
+                    ):
+                        raise RuntimeError("Could not save annotation result.")
+                except Exception as e:  # noqa
+                    error_message = str(e)
+                    failed_images.append((image_file, error_message))
+                    logger.error(
+                        f"Batch image failed: '{image_file}': {error_message}"
+                    )
+                    self.image_failed.emit(image_file, error_message)
                 self.image_index += 1
                 self.progress_updated.emit(
                     self.image_index,
@@ -379,7 +477,9 @@ class BatchProcessingThread(QThread):
                 )
 
             self.app.image_index = self.image_index
-            self.processing_finished.emit()
+            self.processing_finished.emit(
+                len(failed_images), bool(self.app.cancel_processing)
+            )
         except Exception as e:
             self.app.image_index = self.image_index
             self.error_occurred.emit(str(e))
@@ -424,6 +524,7 @@ def process_next_image(self, progress_dialog, batch=True):
             self.text_prompt,
             self.run_tracker,
             skip_detection,
+            visual_prompt=getattr(self, "batch_visual_prompt", False),
         )
 
         def _on_progress(value, label):
@@ -443,7 +544,14 @@ def process_next_image(self, progress_dialog, batch=True):
 
         self._batch_thread.progress_updated.connect(_on_progress)
         self._batch_thread.processing_finished.connect(
-            lambda: finish_processing(self, progress_dialog)
+            lambda failed_count, cancelled: finish_processing(
+                self, progress_dialog, failed_count, cancelled
+            )
+        )
+        self._batch_thread.image_failed.connect(
+            lambda image_file, message: logger.warning(
+                f"Continuing batch after failure for '{image_file}': {message}"
+            )
         )
         self._batch_thread.error_occurred.connect(_on_error)
         self._batch_thread.start()
@@ -637,7 +745,39 @@ def show_progress_dialog_and_process(self):
     QTimer.singleShot(200, lambda: process_next_image(self, progress_dialog))
 
 
-def run_all_images(self):
+def _configure_yoloe_batch(self):
+    """Configure the explicit YOLOE prompt source for one batch run."""
+    model = self.auto_labeling_widget.model_manager.loaded_model_config[
+        "model"
+    ]
+    dialog = YoloeBatchPromptDialog(
+        visual_prompt_ready=model.has_visual_prompt(), parent=self
+    )
+    selection = dialog.get_selection()
+    if selection is None:
+        _reset_batch_processing_state(self)
+        return False
+
+    prompt_mode, self.text_prompt = selection
+    self.batch_visual_prompt = (
+        prompt_mode == YoloeBatchPromptDialog.VISUAL_PROMPT
+    )
+    if self.batch_visual_prompt and not model.has_visual_prompt():
+        self.auto_labeling_widget.model_manager.new_model_status.emit(
+            self.tr("No current visual prompt is ready for batch processing.")
+        )
+        _reset_batch_processing_state(self)
+        return False
+    if self.batch_visual_prompt:
+        # "Run all images" must cover the complete opened folder even when
+        # the reference image is not the first item.
+        self.image_index = 0
+    if prompt_mode == YoloeBatchPromptDialog.PROMPT_FREE:
+        self.text_prompt = ""
+    return True
+
+
+def run_all_images(self):  # noqa: C901
     if getattr(self, "_batch_processing_active", False):
         logger.warning("Batch processing is already running.")
         return
@@ -685,6 +825,7 @@ def run_all_images(self):
     self.image_index = self.current_index
     self.text_prompt = ""
     self.run_tracker = False
+    self.batch_visual_prompt = False
 
     model_type = self.auto_labeling_widget.model_manager.loaded_model_config[
         "type"
@@ -721,10 +862,13 @@ def run_all_images(self):
             [{"type": "auto_grid"}]
         )
         _start_batch_processing(self)
+    elif model_type == "yoloe":
+        if _configure_yoloe_batch(self):
+            _start_batch_processing(self)
     elif model_type in _BATCH_PROCESSING_TEXT_PROMPT_MODELS:
         text_input_dialog = TextInputDialog(parent=self)
         self.text_prompt = text_input_dialog.get_input_text()
-        if self.text_prompt or model_type == "yoloe":
+        if self.text_prompt:
             _start_batch_processing(self)
     elif (
         self.auto_labeling_widget.model_manager.loaded_model_config["type"]

--- a/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
+++ b/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py
@@ -2,7 +2,7 @@ import os
 import yaml
 import collections
 
-from anylabeling.config import get_config
+from anylabeling.config import get_config, get_work_directory
 
 from PyQt6 import uic
 from PyQt6.QtCore import Qt, pyqtSignal, pyqtSlot, QPoint, QTimer
@@ -10,6 +10,7 @@ from PyQt6.QtWidgets import (
     QDialog,
     QFileDialog,
     QHBoxLayout,
+    QInputDialog,
     QLabel,
     QMessageBox,
     QProgressBar,
@@ -136,6 +137,9 @@ class AutoLabelingWidget(QWidget):
         )
         self.model_manager.model_loaded.connect(self.update_visible_widgets)
         self.model_manager.model_loaded.connect(self.on_new_model_loaded)
+        self.model_manager.visual_prompt_status_changed.connect(
+            self.on_visual_prompt_status_changed
+        )
         self.model_manager.new_auto_labeling_result.connect(
             lambda auto_labeling_result: self.parent.new_shapes_from_auto_labeling(
                 auto_labeling_result
@@ -187,6 +191,14 @@ class AutoLabelingWidget(QWidget):
             self.button_add_point.setEnabled(enable)
             self.button_remove_point.setEnabled(enable)
             self.button_add_rect.setEnabled(enable)
+            self.button_generate_visual_prompt.setEnabled(enable)
+            self.button_save_visual_prompt.setEnabled(
+                enable and self._visual_prompt_ready
+            )
+            self.button_load_visual_prompt.setEnabled(enable)
+            self.button_clear_visual_prompt.setEnabled(
+                enable and self._visual_prompt_ready
+            )
             self.add_pos_rect.setEnabled(enable)
             self.add_neg_rect.setEnabled(enable)
             self.button_run_rect.setEnabled(enable)
@@ -215,6 +227,8 @@ class AutoLabelingWidget(QWidget):
         self.initial_preserve_annotations_state = False
         self.skip_detection = False
         self._amg_warning_confirmed = False
+        self._visual_prompt_ready = False
+        self._visual_prompt_state = "NO_VISUAL_PROMPT"
 
         # ===================================
         #  Auto labeling buttons
@@ -315,6 +329,42 @@ class AutoLabelingWidget(QWidget):
         # --- Configuration for: button_add_rect ---
         self.button_add_rect.setText(self.tr("+Rect"))
         self.button_add_rect.clicked.connect(self.on_button_add_rect_clicked)
+
+        # --- Configuration for: cross-image visual prompt controls ---
+        self.button_generate_visual_prompt.setText(
+            self.tr("Generate Visual Prompt")
+        )
+        self.button_generate_visual_prompt.setStyleSheet(
+            get_highlight_button_style()
+        )
+        self.button_generate_visual_prompt.clicked.connect(
+            self.on_generate_visual_prompt_clicked
+        )
+        self.visual_prompt_status_label.setText(
+            self.tr("Visual Prompt: Not generated")
+        )
+        self.visual_prompt_status_label.setStyleSheet(
+            f"color: {get_theme()['text_secondary']}; background: transparent;"
+        )
+        self.button_clear_visual_prompt.setText(self.tr("Clear Visual Prompt"))
+        self.button_clear_visual_prompt.setStyleSheet(
+            get_normal_button_style()
+        )
+        self.button_clear_visual_prompt.setEnabled(False)
+        self.button_clear_visual_prompt.clicked.connect(
+            self.on_clear_visual_prompt_clicked
+        )
+        self.button_save_visual_prompt.setText(self.tr("Save Prompt"))
+        self.button_save_visual_prompt.setStyleSheet(get_normal_button_style())
+        self.button_save_visual_prompt.setEnabled(False)
+        self.button_save_visual_prompt.clicked.connect(
+            self.on_save_visual_prompt_clicked
+        )
+        self.button_load_visual_prompt.setText(self.tr("Load Prompt"))
+        self.button_load_visual_prompt.setStyleSheet(get_normal_button_style())
+        self.button_load_visual_prompt.clicked.connect(
+            self.on_load_visual_prompt_clicked
+        )
 
         # --- Configuration for: add_pos_rect ---
         self.add_pos_rect.setText(self.tr("+Rect"))
@@ -1094,6 +1144,10 @@ class AutoLabelingWidget(QWidget):
         elif model_config.get("type") == "remote_server":
             self.update_remote_server_mode_ui()
 
+        self.on_visual_prompt_status_changed(
+            self.model_manager.get_visual_prompt_status()
+        )
+
     def update_upn_mode_ui(self):
         """Update UPN mode combobox to reflect current backend state"""
         current_mode = self.model_manager.loaded_model_config[
@@ -1165,6 +1219,11 @@ class AutoLabelingWidget(QWidget):
             "button_add_point",
             "button_remove_point",
             "button_add_rect",
+            "button_generate_visual_prompt",
+            "visual_prompt_status_label",
+            "button_save_visual_prompt",
+            "button_load_visual_prompt",
+            "button_clear_visual_prompt",
             "add_pos_rect",
             "add_neg_rect",
             "button_run_rect",
@@ -1221,6 +1280,100 @@ class AutoLabelingWidget(QWidget):
         current_model_name = self.model_manager.loaded_model_config["type"]
         if current_model_name not in _SKIP_PREDICTION_ON_NEW_MARKS_MODELS:
             self.run_prediction()
+
+    def on_generate_visual_prompt_clicked(self):
+        """Generate a cached YOLOE VPE from current rectangle marks."""
+        if self.parent.filename is None:
+            self.model_manager.new_model_status.emit(
+                self.tr(
+                    "Open a reference image before generating a visual prompt."
+                )
+            )
+            return
+        self.model_manager.build_visual_prompt_threading(
+            self.parent.image, self.parent.filename
+        )
+
+    def on_clear_visual_prompt_clicked(self):
+        """Clear the cached YOLOE VPE while preserving other modes."""
+        self.model_manager.clear_visual_prompt()
+
+    def on_save_visual_prompt_clicked(self):
+        """Save the current VPE below the X-AnyLabeling work directory."""
+        default_name = (
+            self.model_manager.get_visual_prompt_status().get("profile_name")
+            or "visual_prompt"
+        )
+        name, accepted = QInputDialog.getText(
+            self,
+            self.tr("Save Visual Prompt"),
+            self.tr("Prompt name:"),
+            text=default_name,
+        )
+        if not accepted or not name.strip():
+            return
+        profile_directory = os.path.join(
+            get_work_directory(), "visual_prompts", name.strip()
+        )
+        if os.path.isdir(profile_directory):
+            answer = QMessageBox.question(
+                self,
+                self.tr("Replace Visual Prompt"),
+                self.tr(
+                    "A profile with this name already exists. Replace it?"
+                ),
+                QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                QMessageBox.StandardButton.No,
+            )
+            if answer != QMessageBox.StandardButton.Yes:
+                return
+        self.model_manager.save_visual_prompt_profile(
+            name.strip(), profile_directory
+        )
+
+    def on_load_visual_prompt_clicked(self):
+        """Choose profile metadata and restore it in a worker thread."""
+        profile_root = os.path.join(get_work_directory(), "visual_prompts")
+        metadata_path, _ = QFileDialog.getOpenFileName(
+            self,
+            self.tr("Load Visual Prompt"),
+            profile_root,
+            self.tr("Visual Prompt Profile (metadata.json)"),
+        )
+        if metadata_path:
+            self.model_manager.load_visual_prompt_profile_threading(
+                metadata_path
+            )
+
+    def on_visual_prompt_status_changed(self, status):
+        """Render YOLOE cross-image prompt state in the compact panel row."""
+        previous_state = self._visual_prompt_state
+        self._visual_prompt_ready = bool(status.get("ready"))
+        state = status.get("state", "NO_VISUAL_PROMPT")
+        self._visual_prompt_state = state
+        if state == "REFERENCE_MARKS_READY":
+            text = self.tr(
+                "Visual Prompt: Reference boxes ready ({count})"
+            ).format(count=status.get("mark_count", 0))
+        elif self._visual_prompt_ready:
+            classes = ", ".join(status.get("classes") or ["object"])
+            profile_name = status.get("profile_name")
+            if profile_name:
+                classes = f"{profile_name}: {classes}"
+            instances = status.get("instance_count", 0)
+            text = self.tr(
+                "Visual Prompt: Ready — {classes} ({instances} instances)"
+            ).format(classes=classes, instances=instances)
+        else:
+            text = self.tr("Visual Prompt: Not generated")
+        self.visual_prompt_status_label.setText(text)
+        self.button_save_visual_prompt.setEnabled(self._visual_prompt_ready)
+        self.button_clear_visual_prompt.setEnabled(self._visual_prompt_ready)
+        if (
+            state == "VISUAL_PROMPT_READY"
+            and previous_state == "REFERENCE_MARKS_READY"
+        ):
+            self.clear_auto_labeling_action_requested.emit()
 
     def on_open(self):
         pass

--- a/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.ui
+++ b/anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.ui
@@ -360,6 +360,41 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="button_generate_visual_prompt">
+       <property name="text">
+        <string>Generate VPE</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="visual_prompt_status_label">
+       <property name="text">
+        <string>VPE: None</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="button_clear_visual_prompt">
+       <property name="text">
+        <string>Clear VPE</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="button_save_visual_prompt">
+       <property name="text">
+        <string>Save Prompt</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="button_load_visual_prompt">
+       <property name="text">
+        <string>Load Prompt</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="add_pos_rect">
        <property name="text">
         <string>+Rect</string>

--- a/docs/cross_image_validation.md
+++ b/docs/cross_image_validation.md
@@ -1,0 +1,4 @@
+# Cross-image validation
+
+The canonical Phase 1 report is
+[`vision_prompt/cross_image_validation.md`](vision_prompt/cross_image_validation.md).

--- a/docs/environment_report.md
+++ b/docs/environment_report.md
@@ -1,0 +1,4 @@
+# Environment report
+
+The canonical Phase 0 report is
+[`vision_prompt/environment.md`](vision_prompt/environment.md).

--- a/docs/vision_prompt/architecture.md
+++ b/docs/vision_prompt/architecture.md
@@ -1,0 +1,187 @@
+# Vision Prompt architecture
+
+## Existing X-AnyLabeling flow
+
+The current implementation is centered on
+`anylabeling/services/auto_labeling/yoloe.py::YOLOE`.
+
+```mermaid
+flowchart LR
+    Canvas[Canvas +Rect] -->|marks| Widget[AutoLabelingWidget]
+    Widget --> Manager[ModelManager]
+    Manager --> YOLOE[YOLOE.predict_shapes]
+    YOLOE -->|prompts + YOLOEVPSegPredictor| Visual[_visual_model]
+    Visual --> Post[postprocess]
+    Post --> Result[AutoLabelingResult]
+    Result --> Shapes[Editable X-AnyLabeling Shapes]
+```
+
+`Canvas.update_auto_labeling_marks()` converts temporary ADD rectangles to
+`{"type": "rectangle", "data": [x1, y1, x2, y2], "label": 1}`.
+`AutoLabelingWidget.on_new_marks()` forwards them through
+`ModelManager.set_auto_labeling_marks()`. YOLOE collects every `data` value,
+assigns class zero, and runs the current image with `YOLOEVPSegPredictor`.
+After inference it clears `self.marks`, converts Ultralytics detections to
+rectangle or polygon `Shape` objects, and returns `AutoLabelingResult`.
+
+YOLOE lazily owns three independent model instances:
+
+- `_text_model`: standard checkpoint with MobileCLIP embeddings set by
+  `set_classes()`; rebuilt when text classes change.
+- `_visual_model`: standard checkpoint used with `YOLOEVPSegPredictor`.
+- `_prompt_free_model`: prompt-free checkpoint with a vocabulary fused from a
+  temporary standard checkpoint.
+
+The instances are released only by `unload()`. In the validated upstream
+implementation, the visual predictor remains attached after intra-image visual
+inference, while the temporary marks are cleared.
+
+## Existing batch flow
+
+`run_all_images()` classifies `yoloe` as a text-prompt batch model. It always
+opens a `TextInputDialog`; an empty value selects prompt-free mode. The worker
+calls the same blocking `ModelManager.predict_shapes(..., batch=True)` for each
+path and saves its `AutoLabelingResult` through the normal X-AnyLabeling JSON
+pipeline. Progress and cancellation already exist.
+
+Visual prompting cannot currently be selected for batch because marks are
+image-local and consumed after one inference, no VPE is retained, and the
+batch-mode selector only represents text/prompt-free state.
+
+## Validated YOLOE cross-image flow
+
+```mermaid
+flowchart LR
+    Ref[Reference image + boxes] --> VP[YOLOEVPSegPredictor<br/>return_vpe=True]
+    VP --> VPE[predictor.vpe]
+    VPE --> Set[model.set_classes]
+    Set --> Reset[model.predictor = None]
+    Reset --> Target[Standard predictor on target images]
+    Target --> Result[Detections]
+```
+
+The currently installed THU-MIG/yoloe API requires the visual predictor only
+for VPE generation. Target inference must occur after setting classes and
+removing that predictor. The measured single-class VPE is `[1, 1, 512]`.
+
+## Implemented Phase 2 backend
+
+```mermaid
+stateDiagram-v2
+    [*] --> NO_VISUAL_PROMPT
+    NO_VISUAL_PROMPT --> REFERENCE_MARKS_READY: draw one or more boxes
+    REFERENCE_MARKS_READY --> VISUAL_PROMPT_READY: generate VPE once
+    VISUAL_PROMPT_READY --> VISUAL_PROMPT_READY: target / batch inference
+    VISUAL_PROMPT_READY --> NO_VISUAL_PROMPT: clear or incompatible model
+```
+
+The state lives with the loaded YOLOE service, not on the canvas. Phase 2 adds
+a dedicated `_cross_image_visual_model`, so `set_classes(VPE)` and predictor
+changes cannot contaminate `_text_model`, legacy `_visual_model`, or
+`_prompt_free_model`.
+
+The production backend now exposes:
+
+- `build_visual_prompt(reference_image, reference_boxes, classes)`
+- `set_visual_prompt(vpe, classes, reference)`
+- `clear_visual_prompt()`
+- `has_visual_prompt()` / `visual_prompt_ready`
+- `predict_with_visual_prompt(target_image)`
+
+`build_visual_prompt()` accepts one or more same-class boxes from a single
+reference image, validates coordinates against the image, resets any existing
+predictor, generates the VPE, sets classes, and removes the visual predictor.
+The cached tensor remains on the model device and is detached from autograd.
+`predict_with_visual_prompt()` uses the ordinary segmentation predictor and
+returns the existing `AutoLabelingResult`/`Shape` representation without
+changing or clearing the cached VPE.
+
+`predict_shapes()` uses the following precedence: temporary marks retain the
+legacy intra-image flow; a non-empty text prompt uses the text model; otherwise
+a ready cached VPE uses the cross-image model; with no ready VPE it uses the
+prompt-free model. Clearing the cross-image state restores prompt-free behavior.
+
+## Implemented Phase 3 panel integration
+
+`AutoLabelingWidget` now exposes Generate, status, and Clear controls only when
+the loaded model declares the YOLOE widget set. Canvas rectangles continue to
+flow through the existing mark signal. `ModelManager` publishes a UI-safe
+status dictionary and runs VPE generation on its existing model execution
+`QThread`; the same execution lock prevents VPE generation and target
+inference from mutating YOLOE concurrently.
+
+```mermaid
+flowchart LR
+    Rect[Canvas +Rect] --> Marks[ModelManager marks]
+    Marks --> Generate[Generate Visual Prompt]
+    Generate --> Worker[Existing model QThread]
+    Worker --> VPE[Dedicated model + cached VPE]
+    VPE --> Status[Ready status]
+    VPE --> Send[Existing Send action]
+    Send --> Shapes[AutoLabelingResult + editable Shapes]
+```
+
+Successful generation removes only the temporary auto-labeling rectangles from
+the canvas. It does not clear the cached VPE. Clear is rejected while the model
+execution thread is busy and otherwise releases only cross-image state.
+The existing postprocess, Shape, result signal, preservation policy, and
+annotation editor remain the only output pipeline.
+
+## Implemented Phase 4 batch flow
+
+YOLOE now presents an explicit batch prompt selector with `Current Visual
+Prompt`, `Text Prompt`, and `Prompt-Free`. Selecting the current prompt starts
+from the first image in the opened folder and passes an explicit visual-prompt
+flag through the existing `BatchProcessingThread` and `ModelManager`.
+
+```mermaid
+flowchart LR
+    Ready[Cached VPE ready] --> Select[Current Visual Prompt]
+    Select --> Existing[Existing BatchProcessingThread]
+    Existing --> A[Image 1]
+    Existing --> B[Image 2]
+    Existing --> C[Image N]
+    A --> Save[Existing JSON save/merge pipeline]
+    B --> Save
+    C --> Save
+```
+
+The explicit backend path bypasses temporary reference marks and calls target
+inference only. It never invokes VPE build or set operations. Progress and
+cancel remain the existing batch mechanisms. Each image is isolated: a read or
+save failure is logged, reported, counted, and skipped without writing an empty
+annotation or stopping later images. The completion popup distinguishes
+success, cancellation, and completion with failed images.
+
+## Implemented Phase 5 profile lifecycle
+
+`VisualPromptProfile` is an independent serialization boundary. A live CUDA
+tensor is converted with `detach().cpu().float().numpy()` and saved as
+`embedding.npz`; JSON-safe model and reference metadata is saved separately as
+`metadata.json`. Python pickle and arbitrary object deserialization are not
+used.
+
+```mermaid
+flowchart LR
+    Live[Live CUDA VPE] --> CPU[CPU float32 NumPy]
+    CPU --> NPZ[embedding.npz]
+    Meta[Model + reference metadata] --> JSON[metadata.json]
+    NPZ --> Verify[Version + SHA-256 + shape/dtype checks]
+    JSON --> Verify
+    Verify --> Compatible[Model compatibility check]
+    Compatible --> Device[Restore to current model device]
+    Device --> Ready[VISUAL_PROMPT_READY]
+```
+
+The metadata file is written last and acts as the commit marker. Loading
+requires profile version 1, a fixed embedding filename, a matching SHA-256,
+finite float32 data, consistent `[1, classes, embedding]` dimensions, valid
+reference boxes, and JSON-only metadata. Compatibility checks model family,
+checkpoint filename and byte size, YOLOE architecture, and embedding
+dimension before changing the live prompt. A failed or incompatible load does
+not replace the current cached VPE.
+
+Profiles are stored below `get_work_directory()/visual_prompts/<name>` by the
+minimal panel action. Loading restores the array through `set_visual_prompt`,
+which moves it to the dedicated model's actual device, binds classes once,
+and resets the encoder predictor before target inference.

--- a/docs/vision_prompt/cross_image_validation.md
+++ b/docs/vision_prompt/cross_image_validation.md
@@ -1,0 +1,46 @@
+# YOLOE cross-image validation
+
+## Result
+
+**Cross-Image Visual Prompt: PASS**
+
+This validation used real YOLOE inference on two different files. No detection,
+VPE, or output image was mocked.
+
+| Field | Value |
+| --- | --- |
+| Model | YOLOE-11-S segmentation |
+| Reference | THU-MIG/yoloe `ultralytics/assets/bus.jpg` |
+| Reference bbox (xyxy) | `[221.52, 405.8, 344.98, 857.54]` (person) |
+| Target | THU-MIG/yoloe `ultralytics/assets/zidane.jpg` |
+| Reference equals target | No |
+| Device | `cuda:0` |
+| VPE shape | `[1, 1, 512]` |
+| VPE dtype | `torch.float32` |
+| Detection count | 2 |
+| Confidences | `0.490147`, `0.209724` |
+| VPE generation | 8.5782 s (includes first predictor setup/warm-up) |
+| Target inference | 0.1750 s |
+| Model load | 0.1451 s |
+
+Target detections (xyxy):
+
+1. `[750.727, 42.665, 1148.404, 716.746]`
+2. `[123.550, 203.331, 1116.964, 716.951]`
+
+Both rendered detections cover people in the target image. The output is
+`tests/output/cross_image_result.jpg`; machine-readable metrics are beside it
+as `cross_image_result.json`. `tests/output/` is ignored so generated evidence
+is not accidentally committed.
+
+## Reproduction
+
+```powershell
+.\.venv\Scripts\python.exe tests\manual\yoloe_cross_image_demo.py
+```
+
+The script validates all paths, rejects identical reference and target paths,
+checks bbox shape/finiteness/bounds, calls the current official `return_vpe`
+API, records the actual predictor VPE, resets `model.predictor`, and performs
+ordinary inference on the target. It returns a non-zero exit status when there
+are no target detections.

--- a/docs/vision_prompt/environment.md
+++ b/docs/vision_prompt/environment.md
@@ -1,0 +1,62 @@
+# Vision Prompt environment report
+
+Validated on 2026-08-24 (Asia/Shanghai).
+
+## Source baseline
+
+| Component | Value |
+| --- | --- |
+| X-AnyLabeling | 4.0.3 (`upstream/main`) |
+| X-AnyLabeling commit | `8eb3fdcf648ce3302e1d13bfbc605d645a57b5ec` |
+| Working branch | `feature/yoloe-cross-image-vpe-batch` |
+| Upstream | `https://github.com/CVHub520/X-AnyLabeling.git` |
+| THU-MIG/yoloe commit | `40cd606cabdbe2b566d6f14a6b162c89206e9a1b` |
+
+The project is an independent repository rooted at `VisionPromptStudio`.
+An unrelated Git repository in the user home directory is not used.
+
+## Runtime
+
+| Component | Value |
+| --- | --- |
+| Python | 3.11.9, isolated in `.venv` |
+| PyTorch | 2.13.0+cu130 |
+| CUDA runtime in PyTorch | 13.0 |
+| CUDA available | Yes |
+| cuDNN | 9.2.0 (`92000`) |
+| GPU | NVIDIA GeForce RTX 5060 Laptop GPU, 8151 MiB |
+| Compute capability | 12.0 |
+| NVIDIA driver | 596.49 |
+| CUDA Toolkit / `nvcc` | Not installed; not required by the wheel runtime |
+| Ultralytics | 8.3.39 from the checked-out THU-MIG/yoloe source |
+| PyQt6 | 6.11.0 |
+| supervision | 0.30.0 |
+| NumPy | 2.4.6 |
+
+The upstream `pyproject.toml` now requires Python 3.11 or newer and declares
+3.11-3.13 support. The older YOLOE example still mentioning Python 3.10 is
+therefore not used as the environment authority for this baseline.
+
+## Models
+
+| File | Bytes | SHA-256 |
+| --- | ---: | --- |
+| `yoloe-11s-seg.pt` | 27,803,986 | `8e439445c87338b79d9ce21dec109f4621e26df67e94d26ea1a98c1e64dce3e3` |
+| `yoloe-11s-seg-pf.pt` | 24,239,013 | `22ed131030aaf1985d34f2ed58576c2fb7f30d5dbe0c435574a1c073c475920f` |
+| `mobileclip_blt.pt` | 599,214,572 | `670844f7a886dd6eff7a9285adfc53f3d3c889c03bfc8354010cb5c6bf27441a` |
+
+The model files live under ignored `.cache/models/` and are not committed.
+YOLOE weights came from the official `jameslahm/yoloe` Hugging Face repository;
+MobileCLIP came from the official `apple/MobileCLIP-B-LT` repository. Their
+byte sizes match the URLs configured or documented by upstream.
+
+## Baseline result
+
+- X-AnyLabeling 4.0.3 Qt event loop and main window initialized successfully
+  with the offscreen Qt platform.
+- GPU tensor allocation and computation passed on `cuda:0`.
+- X-AnyLabeling YOLOE Text Prompt passed: `person.car` produced four editable
+  rectangle Shapes on `bus.jpg`.
+- X-AnyLabeling intra-image Visual Prompt passed: one reference rectangle
+  produced three editable rectangle Shapes on `bus.jpg`.
+- `pip check`: no broken requirements.

--- a/docs/vision_prompt/implementation_notes.md
+++ b/docs/vision_prompt/implementation_notes.md
@@ -1,0 +1,80 @@
+# Implementation notes
+
+## Phase 0-3 changes
+
+| File | Reason | Upstream behavior changed? |
+| --- | --- | --- |
+| `.gitignore` | Exclude generated test output and supplied reference media | No |
+| `tests/manual/yoloe_cross_image_demo.py` | Reproducible real reference-to-target VPE validation | No |
+| `tests/manual/yoloe_xanylabeling_baseline.py` | Reproducible X-AnyLabeling Text and intra-image Visual baseline | No |
+| `tests/manual/yoloe_phase2_integration.py` | Target B/C cache and mode-isolation integration test | No |
+| `docs/vision_prompt/*` | Record environment, architecture, validation, plan, and tests | No |
+| `anylabeling/services/auto_labeling/yoloe.py` | Add the production cross-image VPE lifecycle | Yes, adds an opt-in cached backend mode |
+| `tests/test_models/test_yoloe.py` | Validate state, bbox/VPE compatibility, predictor reset, and clearing | No |
+| `anylabeling/services/auto_labeling/model_manager.py` | Threaded VPE generation, status signal, guarded clearing | Yes, YOLOE-only additive API |
+| `anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.py` | Connect existing panel and canvas marks to the new manager API | Yes, YOLOE-only controls |
+| `anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.ui` | Add Generate, compact state, and Clear widgets | Yes, localized row additions |
+| `tests/test_models/test_yoloe_model_manager.py` | Validate manager state/status/build/clear dispatch | No |
+| `tests/manual/yoloe_phase3_gui_integration.py` | Real Qt worker and Target B/C button flow | No |
+| `anylabeling/views/labeling/utils/batch.py` | Select Current Visual Prompt and reuse it through existing batch worker/save flow | Yes, localized YOLOE mode and per-image error isolation |
+| `tests/test_auto_labeling/test_yoloe_batch.py` | Validate selection, progress, cancellation, error continuation, and folder start | No |
+| `tests/manual/yoloe_phase4_batch_integration.py` | Real CUDA VPE batch over three valid and one damaged image | No |
+| `anylabeling/services/auto_labeling/visual_prompt_profile.py` | Safe JSON/NPZ schema, integrity and compatibility validation | Additive public module |
+| `tests/test_models/test_visual_prompt_profile.py` | Profile round-trip, corruption, version, dtype/shape, and compatibility tests | No |
+| `tests/manual/yoloe_phase5_profile_integration.py` | Real CUDA save/clear/load and Target B/C validation | No |
+
+The original annotation serialization and merge/replace rules remain in place.
+`save_auto_labeling_result()` now returns success/failure so the existing batch
+worker can avoid treating a failed write as a successful image.
+
+## Implemented public model methods
+
+- `build_visual_prompt(reference_image, boxes, classes)`
+- `set_visual_prompt(vpe, classes, reference_metadata)`
+- `clear_visual_prompt()`
+- `has_visual_prompt()`
+- `predict_with_visual_prompt(target_image)`
+- `save_visual_prompt_profile(name, directory)`
+- `load_visual_prompt_profile(path)`
+
+State includes the live VPE, class names, reference metadata, readiness state,
+and a model signature. The live VPE remains ready after target inference.
+Temporary canvas marks are cleared only after successful generation.
+
+## Profile persistence decision
+
+Profiles use schema version 1 with `metadata.json` and `embedding.npz`.
+Metadata includes name/time, configured model name, model signature, reference
+path/image size/boxes/classes, VPE shape/dtype, fixed embedding filename, and
+SHA-256. Files are written through same-directory temporary files and atomic
+replacement, with metadata replaced last. Loading uses
+`numpy.load(..., allow_pickle=False)` and a 64 MiB archive limit.
+
+The panel adds only Save Prompt and Load Prompt actions. Save defaults below
+the existing X-AnyLabeling work directory; Load uses the existing model worker
+thread because restoring a cleared prompt may lazily reload the YOLOE model.
+There is intentionally no profile database, rename/delete manager, multi-image
+reference aggregation, or automatic VPE averaging in the MVP.
+
+## Upstream synchronization risks
+
+- `yoloe.py` is an active integration point and likely conflict area if
+  upstream changes the THU-MIG fork/API.
+- `auto_labeling.py/.ui` and `batch.py` are broad shared surfaces; additions
+  must remain localized.
+- `ModelManager` has a large explicit model loader and shared execution thread;
+  new methods should avoid unrelated restructuring.
+
+## Predictor and model isolation decision
+
+The validated encoder sequence ends with a `YOLOEVPSegPredictor`; target
+inference requires `model.predictor = None`. Setting a VPE also mutates model
+classes. Phase 2 therefore implements a lazily loaded
+`_cross_image_visual_model`. `_visual_model` continues serving legacy
+intra-image prompts unchanged. Real integration verified that text and
+prompt-free model object identities and results survive cross-image round trips.
+
+Profiles serialize `vpe.detach().cpu().float().numpy()` to NPZ and plain
+metadata to JSON. Loading restores a tensor on the current compatible model's
+device. Pickle is not used for profiles. Reference path, boxes, and classes are
+retained so an incompatible VPE can be regenerated.

--- a/docs/vision_prompt/mvp_acceptance_report.md
+++ b/docs/vision_prompt/mvp_acceptance_report.md
@@ -1,0 +1,41 @@
+# VisionPrompt Studio core MVP acceptance
+
+Validated on 2026-08-24 against X-AnyLabeling 4.0.3 at `8eb3fdcf`, YOLOE-11s,
+Ultralytics 8.3.39, and an RTX 5060 Laptop GPU.
+
+## Acceptance result
+
+**Core MVP: PASS**
+
+| Required case | Result | Evidence |
+| --- | --- | --- |
+| A — Reference A finds targets in different Target B | PASS | real `[1,1,512]` VPE; `zidane.jpg` produced 2 editable Shapes |
+| B — same prompt remains usable on Target C | PASS | no rebuild/set; `bus_composite.jpg` produced 4 editable Shapes |
+| C — same prompt processes a folder | PASS | existing Batch worker processed 3 valid images with one VPE/model instance |
+| D — Batch results are normal editable/savable annotations | PASS | existing JSON save/merge pipeline produced Shapes; manual annotation preservation passed |
+
+The user also manually accepted Generate VPE, Target B (2), Target C (4),
+Shape editing, and Clear Visual Prompt in the production GUI.
+
+## Persistence extension
+
+Phase 5 additionally passes save, clear, and load using versioned JSON/NPZ.
+The exact embedding is restored to CUDA, Target B/C results remain 2/4, and
+the target predictor is the ordinary segmentation predictor. Profiles retain
+reference metadata so an incompatible VPE can be regenerated later.
+
+## Regression and safety
+
+- Text → Cross-Image → Text: PASS; text model reused.
+- Prompt-Free → Cross-Image → Prompt-Free: PASS; prompt-free model reused.
+- Batch progress, cancel, individual failure continuation, and annotation
+  preservation: PASS.
+- Profile corruption/version/model compatibility checks: PASS.
+- Focused automated suite: 35 tests and 21 subtests passed.
+- Real Phase 2, Phase 3, Phase 4, and Phase 5 integrations: PASS.
+
+## Deliberately outside this MVP
+
+Multi-reference aggregation, multi-class VPEs, a rename/delete Prompt Manager,
+video/camera prompting, model export, branding, and UI redesign remain future
+work. No unverified VPE averaging has been introduced.

--- a/docs/vision_prompt/phase2_validation.md
+++ b/docs/vision_prompt/phase2_validation.md
@@ -1,0 +1,43 @@
+# Phase 2 backend validation
+
+## Result
+
+**Cross-Image backend state and model isolation: PASS**
+
+The production `YOLOE` service was tested with the real YOLOE-11-S model on
+CUDA. One reference image used two same-class person boxes. A single generated
+VPE was then applied consecutively to Target B and Target C.
+
+| Field | Value |
+| --- | --- |
+| Reference | `bus.jpg` |
+| Reference boxes | 2, unified class `object` |
+| VPE | `[1,1,512]`, float32, cuda:0 |
+| Warm VPE generation | 0.2811 s |
+| Target B | `zidane.jpg`, 2 Shapes, 0.9025 / 0.7868 |
+| Target B inference | 0.1740 s |
+| Target C | `bus_composite.jpg`, 4 Shapes, max 0.9885 |
+| Target C inference | 0.0343 s |
+| Target predictor | `SegmentationPredictor` |
+| VPE regenerated between B/C | No |
+| VPE tensor/model replaced between B/C | No |
+
+Validated mode transitions:
+
+```text
+Text → Cross-Image → Text: PASS
+Prompt-Free → Cross-Image → Prompt-Free: PASS
+```
+
+In both transitions, the original mode-specific model object was reused and
+produced the same labels, boxes, and confidence values after returning from
+Cross-Image mode. The dedicated cross-image model was cleared without deleting
+or changing the other mode instances.
+
+Generated evidence:
+
+- `tests/output/phase2/target_b_result.jpg`
+- `tests/output/phase2/target_c_result.jpg`
+- `tests/output/phase2/phase2_report.json`
+
+The generated output directory remains ignored by Git.

--- a/docs/vision_prompt/phase3_validation.md
+++ b/docs/vision_prompt/phase3_validation.md
@@ -1,0 +1,38 @@
+# Phase 3 Qt integration validation
+
+## Result
+
+**ModelManager worker and Auto Labeling Panel integration: PASS**
+
+The production `AutoLabelingWidget`, `ModelManager`, and `YOLOE` service were
+assembled in a real Qt application with the YOLOE-11-S CUDA model. The test
+used the actual Generate and Send button connections rather than calling the
+YOLOE backend directly.
+
+| Field | Value |
+| --- | --- |
+| Reference | `bus.jpg`, two same-class boxes |
+| Marks state | `Visual Prompt: Reference boxes ready (2)` |
+| Ready state | `Visual Prompt: Ready — object (2 instances)` |
+| VPE | `[1,1,512]`, float32, cuda:0 |
+| VPE generation through QThread | 3.4285 s |
+| Target B | `zidane.jpg`, 2 editable Shapes |
+| Target B inference | 0.1954 s |
+| Target C | `bus_composite.jpg`, 4 editable Shapes |
+| Target C inference | 0.0684 s |
+| Predictor after generation | `SegmentationPredictor` |
+| VPE/model replaced between B and C | No |
+| Clear state | `Visual Prompt: Not generated` |
+
+The panel disabled its controls while the worker was active, removed temporary
+reference rectangles only after successful generation, kept the VPE ready
+across both target images, and disabled Clear after releasing the VPE.
+
+Generated evidence (ignored by Git):
+
+- `tests/output/phase3/auto_labeling_panel.png`
+- `tests/output/phase3/phase3_report.json`
+
+The complete X-AnyLabeling main GUI was also launched independently after the
+integration run. Its process remained in the Qt event loop until the exact test
+process was stopped after eight seconds.

--- a/docs/vision_prompt/phase4_batch_validation.md
+++ b/docs/vision_prompt/phase4_batch_validation.md
@@ -1,0 +1,42 @@
+# Phase 4 Current Visual Prompt batch validation
+
+## Result
+
+**Cached VPE Batch Processing: PASS**
+
+The production `BatchProcessingThread`, `ModelManager`, YOLOE backend, and
+`save_auto_labeling_result()` pipeline were tested with a real CUDA model. The
+VPE was built and set before the worker started, then reused without mutation
+for all batch targets.
+
+| Field | Value |
+| --- | --- |
+| Reference | `bus.jpg`, two person boxes |
+| VPE | `[1,1,512]`, float32, cuda:0 |
+| VPE build calls | 1 total |
+| VPE set calls | 1 total |
+| Valid image 1 | `01_bus.jpg`, 4 object annotations |
+| Valid image 2 | `02_zidane.jpg`, 2 object annotations |
+| Valid image 3 | `03_bus_composite.jpg`, 4 object annotations |
+| Damaged input | `04_broken.jpg`, reported once and skipped |
+| Progress | 1/4, 2/4, 3/4, 4/4 |
+| Batch inference time | 0.4163 s |
+| Target predictor | ordinary segmentation predictor |
+
+The VPE tensor address and dedicated model identity stayed constant. No
+`build_visual_prompt()` or `set_visual_prompt()` call occurred inside the
+batch. A pre-existing `manual_keep` annotation on the second image remained
+and automatic shapes were appended according to the existing preservation
+policy.
+
+The damaged image had a pre-existing sentinel JSON file. That file remained
+byte-equivalent in meaning, proving a failed inference does not save an empty
+result or overwrite existing annotations. Processing continued to completion.
+
+Generated evidence (ignored by Git):
+
+- `tests/output/phase4_batch/phase4_batch_report.json`
+- `tests/output/phase4_batch/labels/01_bus.json`
+- `tests/output/phase4_batch/labels/02_zidane.json`
+- `tests/output/phase4_batch/labels/03_bus_composite.json`
+- `tests/output/phase4_batch/labels/04_broken.json` (preserved sentinel)

--- a/docs/vision_prompt/phase5_profile_validation.md
+++ b/docs/vision_prompt/phase5_profile_validation.md
@@ -1,0 +1,36 @@
+# Phase 5 VisualPromptProfile validation
+
+## Result
+
+**Visual Prompt Persistence: PASS**
+
+The production YOLOE backend generated a real VPE, saved it, cleared all
+cross-image state, loaded it from disk, restored it to CUDA, and ran two
+different target images.
+
+| Field | Value |
+| --- | --- |
+| Profile | `product_A` |
+| Files | `metadata.json` + `embedding.npz` |
+| Schema | version 1 |
+| Stored embedding | NumPy float32, `[1,1,512]` |
+| Restored embedding | torch.float32, cuda:0, exact value match |
+| Reference metadata | image path, size, two boxes, class retained |
+| Target B | `zidane.jpg`, 2 Shapes |
+| Target C | `bus_composite.jpg`, 4 Shapes |
+| Target predictor | `SegmentationPredictor` |
+| Profile load time | 0.0722 s |
+| Result | PASS |
+
+Unit coverage verifies valid round-trip, invalid names/metadata/reference
+boxes, unsupported versions, checksum corruption, shape and dtype mismatch,
+non-finite values, and incompatibility across model family/checkpoint size and
+name/architecture/embedding dimension. NPZ loading explicitly disables
+pickle. The live prompt is changed only after all format and compatibility
+checks pass.
+
+Generated evidence (ignored by Git):
+
+- `tests/output/phase5_profile/phase5_profile_report.json`
+- `tests/output/phase5_profile/visual_prompts/product_A/metadata.json`
+- `tests/output/phase5_profile/visual_prompts/product_A/embedding.npz`

--- a/docs/vision_prompt/test_report.md
+++ b/docs/vision_prompt/test_report.md
@@ -1,0 +1,64 @@
+# Phase 0/1 test report
+
+Validated on 2026-08-24.
+
+| Test | Result | Evidence |
+| --- | --- | --- |
+| Git/source baseline | PASS | branch tracks `upstream/main` at `8eb3fdcf` |
+| X-AnyLabeling startup | PASS | Qt main window/event loop remained active in offscreen mode |
+| CUDA runtime | PASS | real CUDA tensor calculation on RTX 5060 |
+| Existing YOLOE unit/layout tests | PASS | 9 tests passed |
+| Dependency consistency | PASS | `pip check`: no broken requirements |
+| X-AnyLabeling Text Prompt | PASS | 4 `person` rectangle Shapes, scores 0.9276/0.9259/0.9127/0.6366 |
+| X-AnyLabeling intra-image Visual Prompt | PASS | 3 `object0` rectangle Shapes, scores 0.9851/0.9165/0.8525 |
+| Temporary mark consumption | PASS | marks count is zero after intra-image prediction |
+| Cross-image VPE generation | PASS | real VPE `[1,1,512]`, float32, cuda:0 |
+| Different target detection | PASS | 2 detections on `zidane.jpg` |
+| Rendered result | PASS | `tests/output/cross_image_result.jpg`, 67,947 bytes |
+| Phase 2 backend unit tests | PASS | 10 tests plus 10 parameterized subtests |
+| Multiple same-class reference boxes | PASS | 2 boxes produced VPE `[1,1,512]` |
+| Cached VPE on Target B/C | PASS | same tensor and model instance across both targets |
+| Target predictor lifecycle | PASS | ordinary `SegmentationPredictor` after encoding |
+| Text → Cross-Image → Text | PASS | text model reused; results unchanged |
+| Prompt-Free → Cross-Image → Prompt-Free | PASS | prompt-free model reused; results unchanged |
+| Phase 2 Target B | PASS | 2 editable Shapes, confidence 0.9025/0.7868 |
+| Phase 2 Target C | PASS | 4 editable Shapes, confidence up to 0.9885 |
+| Phase 3 ModelManager/UI tests | PASS | 20 tests plus 10 parameterized subtests in focused suite |
+| Generate VPE QThread path | PASS | production panel button used existing model execution worker |
+| Phase 3 Target B/C via Send | PASS | 2 then 4 editable Shapes using one cached VPE |
+| Phase 3 panel state | PASS | marks-ready, VPE-ready, and cleared states displayed |
+| Full application startup after UI change | PASS | main `pythonw` GUI process remained active after 8 seconds |
+| Current Visual Prompt batch selection | PASS | explicit YOLOE mode, defaults to cached VPE when ready |
+| Batch VPE lifecycle | PASS | one build and one set total; same tensor/model for every target |
+| Three-image CUDA Batch | PASS | bus 4, zidane 2, composite 4 editable annotations |
+| Batch progress | PASS | 1/4 through 4/4 including one damaged image |
+| Batch cancel | PASS | worker stops before the next image and reports cancellation |
+| Per-image error continuation | PASS | damaged image logged/skipped; later results retained |
+| Existing annotation policy | PASS | manual `manual_keep` shape preserved and auto results appended |
+| Profile unit suite | PASS | JSON/NPZ round-trip, validation, corruption and compatibility |
+| Profile format safety | PASS | `allow_pickle=False`, SHA-256, fixed filename and 64 MiB limit |
+| Real CUDA profile restore | PASS | exact VPE restored from CPU NPZ to cuda:0 |
+| Loaded profile Target B/C | PASS | 2 then 4 editable Shapes; ordinary predictor |
+| Phase 2–4 regression after persistence | PASS | mode isolation, Qt panel and 3-image Batch all rerun |
+| Formatting check | PASS | Black and `git diff --check` |
+| Repository Flake8 | BASELINE WARNINGS | 5 existing F841/C901 findings outside Phase 3 changes |
+
+Commands used:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest `
+  tests/test_auto_labeling/test_layout.py `
+  tests/test_models/test_yoloe.py `
+  tests/test_models/test_yoloe_model_manager.py -q
+
+.\.venv\Scripts\python.exe tests/manual/yoloe_xanylabeling_baseline.py
+.\.venv\Scripts\python.exe tests/manual/yoloe_cross_image_demo.py
+.\.venv\Scripts\python.exe tests/manual/yoloe_phase2_integration.py
+.\.venv\Scripts\python.exe tests/manual/yoloe_phase3_gui_integration.py
+.\.venv\Scripts\python.exe tests/manual/yoloe_phase4_batch_integration.py
+.\.venv\Scripts\python.exe tests/manual/yoloe_phase5_profile_integration.py
+.\.venv\Scripts\python.exe -m pip check
+```
+
+Profile serialization and Batch integration are validated with the real CUDA
+model. Generated evidence remains below ignored `tests/output/` directories.

--- a/tests/manual/yoloe_cross_image_demo.py
+++ b/tests/manual/yoloe_cross_image_demo.py
@@ -1,0 +1,184 @@
+"""Validate YOLOE cross-image visual prompting with two distinct images.
+
+This is a manual integration test. It requires the THU-MIG/yoloe fork of
+Ultralytics and a YOLOE segmentation checkpoint; it never downloads or mocks
+either input images or detections.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+from ultralytics import YOLOE
+from ultralytics.models.yolo.yoloe.predict_vp import YOLOEVPSegPredictor
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+YOLOE_SOURCE = PROJECT_ROOT / ".cache" / "yoloe"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Generate a VPE on one image and detect on another."
+    )
+    parser.add_argument(
+        "--model",
+        type=Path,
+        default=PROJECT_ROOT / ".cache" / "models" / "yoloe-11s-seg.pt",
+    )
+    parser.add_argument(
+        "--reference",
+        type=Path,
+        default=YOLOE_SOURCE / "ultralytics" / "assets" / "bus.jpg",
+    )
+    parser.add_argument(
+        "--target",
+        type=Path,
+        default=YOLOE_SOURCE / "ultralytics" / "assets" / "zidane.jpg",
+    )
+    parser.add_argument(
+        "--bbox",
+        type=float,
+        nargs=4,
+        action="append",
+        metavar=("X1", "Y1", "X2", "Y2"),
+        help=(
+            "Reference box in xyxy pixels; repeat for multiple instances. "
+            "Defaults to the person box from the official YOLOE demo."
+        ),
+    )
+    parser.add_argument("--imgsz", type=int, default=640)
+    parser.add_argument("--conf", type=float, default=0.10)
+    parser.add_argument("--iou", type=float, default=0.70)
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=PROJECT_ROOT / "tests" / "output" / "cross_image_result.jpg",
+    )
+    return parser.parse_args()
+
+
+def validate_inputs(args: argparse.Namespace) -> np.ndarray:
+    for name in ("model", "reference", "target"):
+        path = getattr(args, name).resolve()
+        if not path.is_file():
+            raise FileNotFoundError(f"{name} does not exist: {path}")
+
+    reference = args.reference.resolve()
+    target = args.target.resolve()
+    if reference == target:
+        raise ValueError("Reference and target images must be different files")
+
+    boxes = np.asarray(
+        args.bbox or [[221.52, 405.8, 344.98, 857.54]],
+        dtype=np.float32,
+    )
+    width, height = Image.open(reference).size
+    if boxes.ndim != 2 or boxes.shape[1] != 4:
+        raise ValueError("Bounding boxes must have shape [N, 4]")
+    if not np.isfinite(boxes).all():
+        raise ValueError("Bounding boxes must contain finite values")
+    if (
+        (boxes[:, 0] < 0).any()
+        or (boxes[:, 1] < 0).any()
+        or (boxes[:, 2] > width).any()
+        or (boxes[:, 3] > height).any()
+        or (boxes[:, 2] <= boxes[:, 0]).any()
+        or (boxes[:, 3] <= boxes[:, 1]).any()
+    ):
+        raise ValueError(
+            f"Bounding boxes must be valid within reference size {width}x{height}"
+        )
+    return boxes
+
+
+def main() -> int:
+    args = parse_args()
+    boxes = validate_inputs(args)
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    model_started = time.perf_counter()
+    model = YOLOE(str(args.model.resolve()))
+    model.eval()
+    model.to(device)
+    model_seconds = time.perf_counter() - model_started
+
+    prompts = {
+        "bboxes": boxes,
+        "cls": np.zeros(len(boxes), dtype=np.int64),
+    }
+    vpe_started = time.perf_counter()
+    model.predict(
+        source=str(args.reference.resolve()),
+        imgsz=args.imgsz,
+        conf=args.conf,
+        iou=args.iou,
+        verbose=False,
+        prompts=prompts,
+        predictor=YOLOEVPSegPredictor,
+        return_vpe=True,
+    )
+    vpe = model.predictor.vpe.detach()
+    vpe_seconds = time.perf_counter() - vpe_started
+
+    model.set_classes(["object"], vpe)
+    model.predictor = None
+
+    target_started = time.perf_counter()
+    results = model.predict(
+        source=str(args.target.resolve()),
+        imgsz=args.imgsz,
+        conf=args.conf,
+        iou=args.iou,
+        verbose=False,
+    )
+    target_seconds = time.perf_counter() - target_started
+
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    rendered_bgr = results[0].plot()
+    Image.fromarray(rendered_bgr[..., ::-1]).save(args.output)
+
+    boxes_result = results[0].boxes
+    confidences = (
+        boxes_result.conf.detach().cpu().tolist()
+        if boxes_result is not None
+        else []
+    )
+    xyxy = (
+        boxes_result.xyxy.detach().cpu().tolist()
+        if boxes_result is not None
+        else []
+    )
+    metrics = {
+        "cross_image_visual_prompt": "PASS" if confidences else "FAIL",
+        "model": str(args.model.resolve()),
+        "reference": str(args.reference.resolve()),
+        "reference_boxes": boxes.tolist(),
+        "target": str(args.target.resolve()),
+        "reference_target_are_distinct": True,
+        "device": str(vpe.device),
+        "vpe_shape": list(vpe.shape),
+        "vpe_dtype": str(vpe.dtype),
+        "detection_count": len(confidences),
+        "confidences": confidences,
+        "detections_xyxy": xyxy,
+        "model_load_seconds": model_seconds,
+        "vpe_generation_seconds": vpe_seconds,
+        "target_inference_seconds": target_seconds,
+        "output": str(args.output.resolve()),
+    }
+    metrics_path = args.output.with_suffix(".json")
+    metrics_path.write_text(
+        json.dumps(metrics, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(json.dumps(metrics, ensure_ascii=False, indent=2))
+    return 0 if confidences else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/manual/yoloe_phase2_integration.py
+++ b/tests/manual/yoloe_phase2_integration.py
@@ -1,0 +1,241 @@
+"""Real-model integration test for the Phase 2 YOLOE backend."""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+from PIL import Image, ImageDraw
+
+from anylabeling import config as anylabeling_config
+from anylabeling.services.auto_labeling.yoloe import YOLOE
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+MODEL_DIR = PROJECT_ROOT / ".cache" / "models"
+ASSET_DIR = PROJECT_ROOT / ".cache" / "yoloe" / "ultralytics" / "assets"
+OUTPUT_DIR = PROJECT_ROOT / "tests" / "output" / "phase2"
+REFERENCE = ASSET_DIR / "bus.jpg"
+TARGET_B = ASSET_DIR / "zidane.jpg"
+TARGET_C = ASSET_DIR / "bus_composite.jpg"
+REFERENCE_BOXES = [
+    [53.44, 400.42, 244.41, 900.67],
+    [221.52, 405.8, 344.98, 857.54],
+]
+
+
+def make_model() -> YOLOE:
+    anylabeling_config.current_config_file = "{}"
+    config = {
+        "type": "yoloe",
+        "name": "yoloe_11s-phase2-integration",
+        "display_name": "YOLOE-11-S Phase 2 Integration",
+        "config_file": str(Path(__file__).resolve()),
+        "model_path": str(MODEL_DIR / "yoloe-11s-seg.pt"),
+        "model_pf_path": str(MODEL_DIR / "yoloe-11s-seg-pf.pt"),
+        "embedding_model_path": str(MODEL_DIR / "mobileclip_blt.pt"),
+        "input_height": 640,
+        "input_width": 640,
+        "iou_threshold": 0.70,
+        "conf_threshold": 0.10,
+        "max_det": 1000,
+        "with_mask": False,
+        "classes": ["person", "car"],
+    }
+    return YOLOE(config, on_message=print)
+
+
+def summarize(result) -> dict:
+    return {
+        "count": len(result.shapes),
+        "labels": [shape.label for shape in result.shapes],
+        "scores": [shape.score for shape in result.shapes],
+        "boxes": [
+            [
+                shape.points[0].x(),
+                shape.points[0].y(),
+                shape.points[2].x(),
+                shape.points[2].y(),
+            ]
+            for shape in result.shapes
+        ],
+    }
+
+
+def render_shapes(image_path: Path, result, output_path: Path) -> None:
+    with Image.open(image_path) as opened_image:
+        image = opened_image.convert("RGB")
+    draw = ImageDraw.Draw(image)
+    for shape in result.shapes:
+        box = [
+            shape.points[0].x(),
+            shape.points[0].y(),
+            shape.points[2].x(),
+            shape.points[2].y(),
+        ]
+        draw.rectangle(box, outline="blue", width=4)
+        draw.text(
+            (box[0], max(0, box[1] - 14)),
+            f"{shape.label} {shape.score:.2f}",
+            fill="blue",
+        )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    image.save(output_path)
+
+
+def main() -> int:
+    for path in (
+        REFERENCE,
+        TARGET_B,
+        TARGET_C,
+        MODEL_DIR / "yoloe-11s-seg.pt",
+        MODEL_DIR / "yoloe-11s-seg-pf.pt",
+        MODEL_DIR / "mobileclip_blt.pt",
+    ):
+        if not path.is_file():
+            raise FileNotFoundError(path)
+
+    model = make_model()
+
+    # Text -> Cross-Image -> Text. The same text model must survive unchanged.
+    text_before = model.predict_shapes(
+        image=True,
+        image_path=str(REFERENCE),
+        text_prompt="person.car",
+    )
+    text_model_id = id(model._text_model)
+
+    model.set_auto_labeling_marks(
+        [
+            {
+                "type": "rectangle",
+                "data": box,
+                "label": 1,
+            }
+            for box in REFERENCE_BOXES
+        ]
+    )
+    vpe_started = time.perf_counter()
+    model.build_visual_prompt(str(REFERENCE))
+    vpe_seconds = time.perf_counter() - vpe_started
+    cached_vpe = model.visual_prompt_vpe
+    cached_vpe_pointer = cached_vpe.data_ptr()
+    cross_model_id = id(model._cross_image_visual_model)
+
+    target_b_started = time.perf_counter()
+    target_b = model.predict_shapes(
+        image=True,
+        image_path=str(TARGET_B),
+        text_prompt="",
+    )
+    target_b_seconds = time.perf_counter() - target_b_started
+
+    target_c_started = time.perf_counter()
+    target_c = model.predict_shapes(
+        image=True,
+        image_path=str(TARGET_C),
+        text_prompt="",
+    )
+    target_c_seconds = time.perf_counter() - target_c_started
+
+    cache_survived_targets = (
+        model.visual_prompt_vpe is cached_vpe
+        and model.visual_prompt_vpe.data_ptr() == cached_vpe_pointer
+        and id(model._cross_image_visual_model) == cross_model_id
+        and model.has_visual_prompt()
+    )
+    target_predictor = type(model._cross_image_visual_model.predictor).__name__
+
+    text_after = model.predict_shapes(
+        image=True,
+        image_path=str(REFERENCE),
+        text_prompt="person.car",
+    )
+    text_model_reused = id(model._text_model) == text_model_id
+
+    # Prompt-Free -> Cross-Image -> Prompt-Free. Clearing only the cross-image
+    # state must leave the prompt-free model alive and reusable.
+    model.clear_visual_prompt()
+    prompt_free_before = model.predict_shapes(
+        image=True,
+        image_path=str(REFERENCE),
+        text_prompt="",
+    )
+    prompt_free_model_id = id(model._prompt_free_model)
+
+    model.build_visual_prompt(
+        str(REFERENCE),
+        reference_boxes=REFERENCE_BOXES,
+    )
+    prompt_free_sequence_visual = model.predict_shapes(
+        image=True,
+        image_path=str(TARGET_B),
+        text_prompt="",
+    )
+    model.clear_visual_prompt()
+    prompt_free_after = model.predict_shapes(
+        image=True,
+        image_path=str(REFERENCE),
+        text_prompt="",
+    )
+    prompt_free_model_reused = (
+        id(model._prompt_free_model) == prompt_free_model_id
+    )
+
+    target_b_output = OUTPUT_DIR / "target_b_result.jpg"
+    target_c_output = OUTPUT_DIR / "target_c_result.jpg"
+    render_shapes(TARGET_B, target_b, target_b_output)
+    render_shapes(TARGET_C, target_c, target_c_output)
+
+    checks = {
+        "text_before_detected": bool(text_before.shapes),
+        "target_b_detected": bool(target_b.shapes),
+        "target_c_detected": bool(target_c.shapes),
+        "cache_survived_targets": cache_survived_targets,
+        "target_uses_standard_predictor": (
+            target_predictor != "YOLOEVPSegPredictor"
+        ),
+        "text_after_detected": bool(text_after.shapes),
+        "text_model_reused": text_model_reused,
+        "prompt_free_before_detected": bool(prompt_free_before.shapes),
+        "prompt_free_sequence_visual_detected": bool(
+            prompt_free_sequence_visual.shapes
+        ),
+        "prompt_free_after_detected": bool(prompt_free_after.shapes),
+        "prompt_free_model_reused": prompt_free_model_reused,
+    }
+    report = {
+        "result": "PASS" if all(checks.values()) else "FAIL",
+        "checks": checks,
+        "reference": str(REFERENCE.resolve()),
+        "reference_boxes": REFERENCE_BOXES,
+        "target_b": str(TARGET_B.resolve()),
+        "target_c": str(TARGET_C.resolve()),
+        "vpe_shape": list(cached_vpe.shape),
+        "vpe_dtype": str(cached_vpe.dtype),
+        "vpe_device": str(cached_vpe.device),
+        "vpe_generation_seconds": vpe_seconds,
+        "target_b_seconds": target_b_seconds,
+        "target_c_seconds": target_c_seconds,
+        "target_predictor": target_predictor,
+        "text_before": summarize(text_before),
+        "target_b_result": summarize(target_b),
+        "target_c_result": summarize(target_c),
+        "text_after": summarize(text_after),
+        "prompt_free_before": summarize(prompt_free_before),
+        "prompt_free_visual": summarize(prompt_free_sequence_visual),
+        "prompt_free_after": summarize(prompt_free_after),
+        "target_b_output": str(target_b_output.resolve()),
+        "target_c_output": str(target_c_output.resolve()),
+    }
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    (OUTPUT_DIR / "phase2_report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    model.unload()
+    return 0 if report["result"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/manual/yoloe_phase3_gui_integration.py
+++ b/tests/manual/yoloe_phase3_gui_integration.py
@@ -1,0 +1,241 @@
+"""Real Qt-panel integration test for Phase 3 cross-image YOLOE."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6 import QtCore, QtWidgets
+
+import anylabeling.resources.resources  # noqa: F401
+from anylabeling import config as anylabeling_config
+from anylabeling.services.auto_labeling.yoloe import YOLOE
+from anylabeling.views.labeling.widgets.auto_labeling.auto_labeling import (
+    AutoLabelingWidget,
+)
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+MODEL_DIR = PROJECT_ROOT / ".cache" / "models"
+ASSET_DIR = PROJECT_ROOT / ".cache" / "yoloe" / "ultralytics" / "assets"
+OUTPUT_DIR = PROJECT_ROOT / "tests" / "output" / "phase3"
+REFERENCE = ASSET_DIR / "bus.jpg"
+TARGET_B = ASSET_DIR / "zidane.jpg"
+TARGET_C = ASSET_DIR / "bus_composite.jpg"
+REFERENCE_BOXES = [
+    [53.44, 400.42, 244.41, 900.67],
+    [221.52, 405.8, 344.98, 857.54],
+]
+
+
+class PanelParent:
+    """Small LabelWidget stand-in; the tested panel itself is production UI."""
+
+    def __init__(self):
+        self._config = anylabeling_config.get_config()
+        self.image = True
+        self.filename = str(REFERENCE)
+        self.results = []
+
+    def new_shapes_from_auto_labeling(self, result):
+        self.results.append(result)
+
+
+def make_model() -> YOLOE:
+    config = {
+        "type": "yoloe",
+        "name": "yoloe_11s-phase3-gui-integration",
+        "display_name": "YOLOE-11-S Phase 3 GUI Integration",
+        "config_file": str(Path(__file__).resolve()),
+        "model_path": str(MODEL_DIR / "yoloe-11s-seg.pt"),
+        "model_pf_path": str(MODEL_DIR / "yoloe-11s-seg-pf.pt"),
+        "embedding_model_path": str(MODEL_DIR / "mobileclip_blt.pt"),
+        "input_height": 640,
+        "input_width": 640,
+        "iou_threshold": 0.70,
+        "conf_threshold": 0.10,
+        "max_det": 1000,
+        "with_mask": False,
+        "classes": ["person", "car"],
+    }
+    return YOLOE(config, on_message=print)
+
+
+def wait_for_prediction(manager, action, timeout_ms=120_000):
+    loop = QtCore.QEventLoop()
+    timed_out = False
+
+    def on_timeout():
+        nonlocal timed_out
+        timed_out = True
+        loop.quit()
+
+    timer = QtCore.QTimer()
+    timer.setSingleShot(True)
+    timer.timeout.connect(on_timeout)
+    manager.prediction_finished.connect(loop.quit)
+    timer.start(timeout_ms)
+    action()
+    loop.exec()
+    timer.stop()
+    manager.prediction_finished.disconnect(loop.quit)
+    if timed_out:
+        raise TimeoutError("GUI model worker did not finish in time.")
+
+
+def summarize(result):
+    return {
+        "count": len(result.shapes),
+        "labels": [shape.label for shape in result.shapes],
+        "scores": [shape.score for shape in result.shapes],
+    }
+
+
+def main() -> int:
+    for path in (
+        REFERENCE,
+        TARGET_B,
+        TARGET_C,
+        MODEL_DIR / "yoloe-11s-seg.pt",
+        MODEL_DIR / "yoloe-11s-seg-pf.pt",
+        MODEL_DIR / "mobileclip_blt.pt",
+    ):
+        if not path.is_file():
+            raise FileNotFoundError(path)
+
+    anylabeling_config.current_config_file = "{}"
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication(sys.argv)
+    parent = PanelParent()
+    panel = AutoLabelingWidget(parent)
+    panel.resize(1600, panel.sizeHint().height())
+    panel.show()
+    app.processEvents()
+
+    model = make_model()
+    model_config = {
+        "type": "yoloe",
+        "name": model.config["name"],
+        "display_name": model.config["display_name"],
+        "iou_threshold": model.iou_thres,
+        "conf_threshold": model.conf_thres,
+        "model": model,
+    }
+    panel.model_manager.loaded_model_config = model_config
+    panel.model_manager.model_loaded.emit(model_config)
+    app.processEvents()
+
+    marks = [
+        {"type": "rectangle", "data": box, "label": 1}
+        for box in REFERENCE_BOXES
+    ]
+    cleared_marks = []
+    panel.clear_auto_labeling_action_requested.connect(
+        lambda: cleared_marks.append(True)
+    )
+    panel.on_new_marks(marks)
+    app.processEvents()
+    marks_status = panel.visual_prompt_status_label.text()
+
+    generation_started = time.perf_counter()
+    wait_for_prediction(
+        panel.model_manager,
+        panel.button_generate_visual_prompt.click,
+    )
+    generation_seconds = time.perf_counter() - generation_started
+    app.processEvents()
+    ready_status = panel.visual_prompt_status_label.text()
+    vpe = model.visual_prompt_vpe
+    vpe_pointer = vpe.data_ptr()
+    cross_model_id = id(model._cross_image_visual_model)
+
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    panel.grab().save(str(OUTPUT_DIR / "auto_labeling_panel.png"))
+
+    parent.filename = str(TARGET_B)
+    target_b_started = time.perf_counter()
+    wait_for_prediction(panel.model_manager, panel.button_send.click)
+    target_b_seconds = time.perf_counter() - target_b_started
+    app.processEvents()
+    target_b = parent.results[-1]
+
+    parent.filename = str(TARGET_C)
+    target_c_started = time.perf_counter()
+    wait_for_prediction(panel.model_manager, panel.button_send.click)
+    target_c_seconds = time.perf_counter() - target_c_started
+    app.processEvents()
+    target_c = parent.results[-1]
+
+    cache_survived = (
+        model.visual_prompt_vpe is vpe
+        and model.visual_prompt_vpe.data_ptr() == vpe_pointer
+        and id(model._cross_image_visual_model) == cross_model_id
+        and model.has_visual_prompt()
+    )
+    target_predictor = type(model._cross_image_visual_model.predictor).__name__
+
+    panel.button_clear_visual_prompt.click()
+    app.processEvents()
+    cleared_status = panel.visual_prompt_status_label.text()
+
+    checks = {
+        "controls_visible_for_yoloe": all(
+            widget.isVisible()
+            for widget in (
+                panel.button_generate_visual_prompt,
+                panel.visual_prompt_status_label,
+                panel.button_clear_visual_prompt,
+            )
+        ),
+        "marks_status_displayed": "Reference boxes ready (2)" in marks_status,
+        "vpe_ready_status_displayed": "Ready" in ready_status,
+        "temporary_marks_clear_requested": bool(cleared_marks),
+        "vpe_generated_on_cuda": str(vpe.device).startswith("cuda"),
+        "target_b_detected": bool(target_b.shapes),
+        "target_c_detected": bool(target_c.shapes),
+        "cache_survived_targets": cache_survived,
+        "target_uses_standard_predictor": (
+            target_predictor != "YOLOEVPSegPredictor"
+        ),
+        "clear_removed_vpe": not model.has_visual_prompt(),
+        "clear_status_displayed": "Not generated" in cleared_status,
+        "clear_button_disabled": not panel.button_clear_visual_prompt.isEnabled(),
+    }
+    report = {
+        "result": "PASS" if all(checks.values()) else "FAIL",
+        "checks": checks,
+        "reference": str(REFERENCE.resolve()),
+        "reference_boxes": REFERENCE_BOXES,
+        "target_b": str(TARGET_B.resolve()),
+        "target_c": str(TARGET_C.resolve()),
+        "marks_status": marks_status,
+        "ready_status": ready_status,
+        "cleared_status": cleared_status,
+        "vpe_shape": list(vpe.shape),
+        "vpe_dtype": str(vpe.dtype),
+        "vpe_device": str(vpe.device),
+        "vpe_generation_seconds": generation_seconds,
+        "target_b_seconds": target_b_seconds,
+        "target_c_seconds": target_c_seconds,
+        "target_predictor": target_predictor,
+        "target_b_result": summarize(target_b),
+        "target_c_result": summarize(target_c),
+        "panel_screenshot": str(
+            (OUTPUT_DIR / "auto_labeling_panel.png").resolve()
+        ),
+    }
+    (OUTPUT_DIR / "phase3_report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+
+    panel.close()
+    model.unload()
+    return 0 if report["result"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/manual/yoloe_phase4_batch_integration.py
+++ b/tests/manual/yoloe_phase4_batch_integration.py
@@ -1,0 +1,284 @@
+"""Real X-AnyLabeling BatchProcessingThread test with one cached YOLOE VPE."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PyQt6 import QtCore, QtWidgets
+
+from anylabeling import config as anylabeling_config
+from anylabeling.services.auto_labeling.model_manager import ModelManager
+from anylabeling.services.auto_labeling.yoloe import YOLOE
+from anylabeling.views.labeling.utils.batch import BatchProcessingThread
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+MODEL_DIR = PROJECT_ROOT / ".cache" / "models"
+ASSET_DIR = PROJECT_ROOT / ".cache" / "yoloe" / "ultralytics" / "assets"
+OUTPUT_ROOT = PROJECT_ROOT / "tests" / "output" / "phase4_batch"
+INPUT_DIR = OUTPUT_ROOT / "images"
+LABEL_DIR = OUTPUT_ROOT / "labels"
+REFERENCE = ASSET_DIR / "bus.jpg"
+REFERENCE_BOXES = [
+    [53.44, 400.42, 244.41, 900.67],
+    [221.52, 405.8, 344.98, 857.54],
+]
+
+
+def make_model() -> YOLOE:
+    config = {
+        "type": "yoloe",
+        "name": "yoloe_11s-phase4-batch-integration",
+        "display_name": "YOLOE-11-S Phase 4 Batch Integration",
+        "config_file": str(Path(__file__).resolve()),
+        "model_path": str(MODEL_DIR / "yoloe-11s-seg.pt"),
+        "model_pf_path": str(MODEL_DIR / "yoloe-11s-seg-pf.pt"),
+        "embedding_model_path": str(MODEL_DIR / "mobileclip_blt.pt"),
+        "input_height": 640,
+        "input_width": 640,
+        "iou_threshold": 0.70,
+        "conf_threshold": 0.10,
+        "max_det": 1000,
+        "with_mask": False,
+        "classes": ["person", "car"],
+    }
+    return YOLOE(config, on_message=print)
+
+
+def prepare_batch_files():
+    INPUT_DIR.mkdir(parents=True, exist_ok=True)
+    LABEL_DIR.mkdir(parents=True, exist_ok=True)
+    sources = [
+        (ASSET_DIR / "bus.jpg", INPUT_DIR / "01_bus.jpg"),
+        (ASSET_DIR / "zidane.jpg", INPUT_DIR / "02_zidane.jpg"),
+        (
+            ASSET_DIR / "bus_composite.jpg",
+            INPUT_DIR / "03_bus_composite.jpg",
+        ),
+    ]
+    for source, target in sources:
+        shutil.copy2(source, target)
+    broken = INPUT_DIR / "04_broken.jpg"
+    broken.write_bytes(b"not a valid image")
+
+    for label_file in LABEL_DIR.glob("*.json"):
+        label_file.unlink()
+
+    manual_shape = {
+        "label": "manual_keep",
+        "score": None,
+        "points": [[1, 1], [5, 1], [5, 5], [1, 5]],
+        "group_id": None,
+        "description": "existing annotation",
+        "difficult": False,
+        "shape_type": "rectangle",
+        "flags": {},
+        "attributes": {},
+        "kie_linking": [],
+    }
+    existing = {
+        "version": "4.0.3",
+        "flags": {},
+        "shapes": [manual_shape],
+        "imagePath": "02_zidane.jpg",
+        "imageData": None,
+        "imageHeight": 720,
+        "imageWidth": 1280,
+        "description": "",
+    }
+    (LABEL_DIR / "02_zidane.json").write_text(
+        json.dumps(existing, indent=2), encoding="utf-8"
+    )
+    (LABEL_DIR / "04_broken.json").write_text(
+        json.dumps({"sentinel": "keep"}, indent=2), encoding="utf-8"
+    )
+    return [str(target) for _source, target in sources] + [str(broken)]
+
+
+def main() -> int:
+    for path in (
+        REFERENCE,
+        ASSET_DIR / "zidane.jpg",
+        ASSET_DIR / "bus_composite.jpg",
+        MODEL_DIR / "yoloe-11s-seg.pt",
+        MODEL_DIR / "yoloe-11s-seg-pf.pt",
+        MODEL_DIR / "mobileclip_blt.pt",
+    ):
+        if not path.is_file():
+            raise FileNotFoundError(path)
+
+    anylabeling_config.current_config_file = "{}"
+    qt_app = QtWidgets.QApplication.instance() or QtWidgets.QApplication(
+        sys.argv
+    )
+    assert qt_app is not None
+    image_list = prepare_batch_files()
+    model = make_model()
+
+    counts = {"build_visual_prompt": 0, "set_visual_prompt": 0}
+    original_build = model.build_visual_prompt
+    original_set = model.set_visual_prompt
+
+    def counted_build(*args, **kwargs):
+        counts["build_visual_prompt"] += 1
+        return original_build(*args, **kwargs)
+
+    def counted_set(*args, **kwargs):
+        counts["set_visual_prompt"] += 1
+        return original_set(*args, **kwargs)
+
+    model.build_visual_prompt = counted_build
+    model.set_visual_prompt = counted_set
+    model.set_auto_labeling_marks(
+        [
+            {"type": "rectangle", "data": box, "label": 1}
+            for box in REFERENCE_BOXES
+        ]
+    )
+    model.build_visual_prompt(str(REFERENCE))
+    model.set_auto_labeling_preserve_existing_annotations_state(True)
+
+    cached_vpe = model.visual_prompt_vpe
+    vpe_pointer = cached_vpe.data_ptr()
+    cross_model_id = id(model._cross_image_visual_model)
+
+    manager = ModelManager()
+    manager.loaded_model_config = {"type": "yoloe", "model": model}
+    app = SimpleNamespace(
+        auto_labeling_widget=SimpleNamespace(model_manager=manager),
+        image=True,
+        output_dir=str(LABEL_DIR),
+        _config={"store_data": False},
+        cancel_processing=False,
+        image_index=0,
+    )
+
+    progress = []
+    failed = []
+    finished = []
+    fatal_errors = []
+    worker = BatchProcessingThread(
+        app,
+        image_list,
+        0,
+        "yoloe",
+        "",
+        False,
+        False,
+        visual_prompt=True,
+    )
+    worker.progress_updated.connect(
+        lambda value, label: progress.append([value, label])
+    )
+    worker.image_failed.connect(
+        lambda filename, message: failed.append(
+            {"image": filename, "message": message}
+        )
+    )
+    worker.processing_finished.connect(
+        lambda count, cancelled: finished.append(
+            {"failed_count": count, "cancelled": cancelled}
+        )
+    )
+    worker.error_occurred.connect(fatal_errors.append)
+
+    loop = QtCore.QEventLoop()
+    timeout = QtCore.QTimer()
+    timeout.setSingleShot(True)
+    timeout.timeout.connect(loop.quit)
+    worker.finished.connect(loop.quit)
+    timeout.start(120_000)
+    started = time.perf_counter()
+    worker.start()
+    loop.exec()
+    elapsed = time.perf_counter() - started
+    timed_out = timeout.remainingTime() == -1 and worker.isRunning()
+    timeout.stop()
+    worker.wait(5_000)
+
+    label_files = sorted(LABEL_DIR.glob("*.json"))
+    valid_labels = {}
+    for name in ("01_bus.json", "02_zidane.json", "03_bus_composite.json"):
+        path = LABEL_DIR / name
+        if path.is_file():
+            valid_labels[name] = json.loads(path.read_text(encoding="utf-8"))
+    broken_data = json.loads(
+        (LABEL_DIR / "04_broken.json").read_text(encoding="utf-8")
+    )
+    detection_counts = {
+        name: len(
+            [
+                shape
+                for shape in data["shapes"]
+                if shape.get("label") == "object"
+            ]
+        )
+        for name, data in valid_labels.items()
+    }
+    existing_labels = [
+        shape.get("label")
+        for shape in valid_labels["02_zidane.json"]["shapes"]
+    ]
+
+    checks = {
+        "three_valid_annotations_saved": len(valid_labels) == 3,
+        "three_different_images_detected": all(
+            count > 0 for count in detection_counts.values()
+        ),
+        "vpe_generated_once": counts["build_visual_prompt"] == 1,
+        "vpe_set_once": counts["set_visual_prompt"] == 1,
+        "same_vpe_reused": (
+            model.visual_prompt_vpe is cached_vpe
+            and model.visual_prompt_vpe.data_ptr() == vpe_pointer
+        ),
+        "same_model_reused": id(model._cross_image_visual_model)
+        == cross_model_id,
+        "standard_target_predictor": type(
+            model._cross_image_visual_model.predictor
+        ).__name__
+        != "YOLOEVPSegPredictor",
+        "progress_reached_all_inputs": [item[0] for item in progress]
+        == [1, 2, 3, 4],
+        "broken_image_reported_once": len(failed) == 1,
+        "broken_annotation_preserved": broken_data == {"sentinel": "keep"},
+        "existing_annotation_preserved": "manual_keep" in existing_labels,
+        "batch_finished_without_fatal_error": (
+            finished == [{"failed_count": 1, "cancelled": False}]
+            and not fatal_errors
+            and not timed_out
+        ),
+    }
+    report = {
+        "result": "PASS" if all(checks.values()) else "FAIL",
+        "checks": checks,
+        "reference": str(REFERENCE.resolve()),
+        "reference_boxes": REFERENCE_BOXES,
+        "batch_images": image_list,
+        "elapsed_seconds": elapsed,
+        "vpe_shape": list(cached_vpe.shape),
+        "vpe_dtype": str(cached_vpe.dtype),
+        "vpe_device": str(cached_vpe.device),
+        "vpe_calls": counts,
+        "detection_counts": detection_counts,
+        "progress": progress,
+        "failed_images": failed,
+        "saved_label_files": [str(path.resolve()) for path in label_files],
+        "output_directory": str(LABEL_DIR.resolve()),
+    }
+    (OUTPUT_ROOT / "phase4_batch_report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    model.unload()
+    return 0 if report["result"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/manual/yoloe_phase5_profile_integration.py
+++ b/tests/manual/yoloe_phase5_profile_integration.py
@@ -1,0 +1,128 @@
+"""Real CUDA save/clear/load test for VisualPromptProfile."""
+
+from __future__ import annotations
+
+import json
+import shutil
+import time
+from pathlib import Path
+
+import numpy as np
+
+from anylabeling import config as anylabeling_config
+from anylabeling.services.auto_labeling.yoloe import YOLOE
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+MODEL_DIR = PROJECT_ROOT / ".cache" / "models"
+ASSET_DIR = PROJECT_ROOT / ".cache" / "yoloe" / "ultralytics" / "assets"
+OUTPUT_DIR = PROJECT_ROOT / "tests" / "output" / "phase5_profile"
+PROFILE_DIR = OUTPUT_DIR / "visual_prompts" / "product_A"
+REFERENCE = ASSET_DIR / "bus.jpg"
+TARGET_B = ASSET_DIR / "zidane.jpg"
+TARGET_C = ASSET_DIR / "bus_composite.jpg"
+REFERENCE_BOXES = [
+    [53.44, 400.42, 244.41, 900.67],
+    [221.52, 405.8, 344.98, 857.54],
+]
+
+
+def make_model() -> YOLOE:
+    config = {
+        "type": "yoloe",
+        "name": "yoloe_11s-phase5-profile-integration",
+        "display_name": "YOLOE-11-S Phase 5 Profile Integration",
+        "config_file": str(Path(__file__).resolve()),
+        "model_path": str(MODEL_DIR / "yoloe-11s-seg.pt"),
+        "model_pf_path": str(MODEL_DIR / "yoloe-11s-seg-pf.pt"),
+        "embedding_model_path": str(MODEL_DIR / "mobileclip_blt.pt"),
+        "input_height": 640,
+        "input_width": 640,
+        "iou_threshold": 0.70,
+        "conf_threshold": 0.10,
+        "max_det": 1000,
+        "with_mask": False,
+        "classes": ["person", "car"],
+    }
+    return YOLOE(config, on_message=print)
+
+
+def main() -> int:
+    required = (
+        REFERENCE,
+        TARGET_B,
+        TARGET_C,
+        MODEL_DIR / "yoloe-11s-seg.pt",
+        MODEL_DIR / "yoloe-11s-seg-pf.pt",
+        MODEL_DIR / "mobileclip_blt.pt",
+    )
+    for path in required:
+        if not path.is_file():
+            raise FileNotFoundError(path)
+    anylabeling_config.current_config_file = "{}"
+    if PROFILE_DIR.exists():
+        shutil.rmtree(PROFILE_DIR)
+
+    model = make_model()
+    started = time.perf_counter()
+    model.build_visual_prompt(str(REFERENCE), reference_boxes=REFERENCE_BOXES)
+    generated_vpe = model.visual_prompt_vpe.detach().cpu().clone()
+    generation_seconds = time.perf_counter() - started
+    metadata_path = Path(
+        model.save_visual_prompt_profile("product_A", PROFILE_DIR)
+    )
+    metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+
+    model.clear_visual_prompt()
+    cleared = not model.has_visual_prompt()
+    started = time.perf_counter()
+    profile = model.load_visual_prompt_profile(metadata_path)
+    load_seconds = time.perf_counter() - started
+    restored_vpe = model.visual_prompt_vpe.detach().cpu()
+
+    target_b = model.predict_with_visual_prompt(str(TARGET_B))
+    target_c = model.predict_with_visual_prompt(str(TARGET_C))
+    predictor_name = type(model._cross_image_visual_model.predictor).__name__
+    checks = {
+        "metadata_json_exists": metadata_path.is_file(),
+        "embedding_npz_exists": (PROFILE_DIR / "embedding.npz").is_file(),
+        "profile_version_is_one": metadata["version"] == 1,
+        "reference_metadata_preserved": (
+            profile.reference["image_path"] == str(REFERENCE.resolve())
+            and np.allclose(profile.reference["boxes"], REFERENCE_BOXES)
+        ),
+        "cache_cleared_before_load": cleared,
+        "embedding_round_trip_exact": generated_vpe.equal(restored_vpe),
+        "restored_to_cuda": model.visual_prompt_vpe.device.type == "cuda",
+        "restored_float32": str(model.visual_prompt_vpe.dtype)
+        == "torch.float32",
+        "target_b_detected": len(target_b.shapes) > 0,
+        "target_c_detected": len(target_c.shapes) > 0,
+        "standard_target_predictor": predictor_name != "YOLOEVPSegPredictor",
+        "profile_stays_ready": model.has_visual_prompt(),
+    }
+    report = {
+        "result": "PASS" if all(checks.values()) else "FAIL",
+        "checks": checks,
+        "profile": profile.name,
+        "metadata_path": str(metadata_path.resolve()),
+        "embedding_path": str((PROFILE_DIR / "embedding.npz").resolve()),
+        "vpe_shape": list(model.visual_prompt_vpe.shape),
+        "vpe_dtype": str(model.visual_prompt_vpe.dtype),
+        "vpe_device": str(model.visual_prompt_vpe.device),
+        "target_b_detection_count": len(target_b.shapes),
+        "target_c_detection_count": len(target_c.shapes),
+        "target_predictor": predictor_name,
+        "generation_seconds": generation_seconds,
+        "profile_load_seconds": load_seconds,
+    }
+    OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+    (OUTPUT_DIR / "phase5_profile_report.json").write_text(
+        json.dumps(report, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    model.unload()
+    return 0 if report["result"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/manual/yoloe_xanylabeling_baseline.py
+++ b/tests/manual/yoloe_xanylabeling_baseline.py
@@ -1,0 +1,115 @@
+"""Exercise X-AnyLabeling's existing YOLOE text and visual modes."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from anylabeling import config as anylabeling_config
+from anylabeling.services.auto_labeling.yoloe import YOLOE
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MODELS = PROJECT_ROOT / ".cache" / "models"
+DEFAULT_REFERENCE = (
+    PROJECT_ROOT / ".cache" / "yoloe" / "ultralytics" / "assets" / "bus.jpg"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--image", type=Path, default=DEFAULT_REFERENCE)
+    parser.add_argument(
+        "--model",
+        type=Path,
+        default=DEFAULT_MODELS / "yoloe-11s-seg.pt",
+    )
+    parser.add_argument(
+        "--prompt-free-model",
+        type=Path,
+        default=DEFAULT_MODELS / "yoloe-11s-seg-pf.pt",
+    )
+    parser.add_argument(
+        "--embedding-model",
+        type=Path,
+        default=DEFAULT_MODELS / "mobileclip_blt.pt",
+    )
+    return parser.parse_args()
+
+
+def summarize(result) -> dict:
+    return {
+        "shape_count": len(result.shapes),
+        "labels": [shape.label for shape in result.shapes],
+        "scores": [shape.score for shape in result.shapes],
+        "shape_types": [shape.shape_type for shape in result.shapes],
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    for path in (
+        args.image,
+        args.model,
+        args.prompt_free_model,
+        args.embedding_model,
+    ):
+        if not path.is_file():
+            raise FileNotFoundError(path)
+
+    # The desktop entry point normally initializes this before Model creation.
+    anylabeling_config.current_config_file = "{}"
+    config = {
+        "type": "yoloe",
+        "name": "yoloe_11s-baseline",
+        "display_name": "YOLOE-11-S Baseline",
+        "config_file": str(PROJECT_ROOT / "tests" / "manual"),
+        "model_path": str(args.model.resolve()),
+        "model_pf_path": str(args.prompt_free_model.resolve()),
+        "embedding_model_path": str(args.embedding_model.resolve()),
+        "input_height": 640,
+        "input_width": 640,
+        "iou_threshold": 0.70,
+        "conf_threshold": 0.25,
+        "max_det": 1000,
+        "with_mask": False,
+    }
+    model = YOLOE(config, on_message=lambda message: print(message))
+    image_path = str(args.image.resolve())
+
+    text_result = model.predict_shapes(
+        image=True,
+        image_path=image_path,
+        text_prompt="person.car",
+    )
+
+    model.set_auto_labeling_marks(
+        [
+            {
+                "type": "rectangle",
+                "data": [221, 405, 345, 858],
+                "label": 1,
+            }
+        ]
+    )
+    visual_result = model.predict_shapes(image=True, image_path=image_path)
+    predictor_after_visual = type(model._visual_model.predictor).__name__
+
+    report = {
+        "text_prompt": summarize(text_result),
+        "intra_image_visual_prompt": summarize(visual_result),
+        "visual_marks_remaining": len(model.marks),
+        "visual_predictor_after_inference": predictor_after_visual,
+        "result": (
+            "PASS"
+            if text_result.shapes and visual_result.shapes and not model.marks
+            else "FAIL"
+        ),
+    }
+    print(json.dumps(report, ensure_ascii=False, indent=2))
+    model.unload()
+    return 0 if report["result"] == "PASS" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_auto_labeling/test_layout.py
+++ b/tests/test_auto_labeling/test_layout.py
@@ -89,7 +89,7 @@ class TestAutoLabelingLayout(unittest.TestCase):
         slider = form.findChild(QtWidgets.QSlider, "mask_fineness_slider")
         self.assertGreaterEqual(slider.minimumWidth(), 120)
 
-        form.resize(5000, 100)
+        form.resize(container.sizeHint().width() + 500, 100)
         form.show()
         self.app.processEvents()
         update_model_selection_scroll_area_height(scroll_area)
@@ -184,6 +184,70 @@ class TestAutoLabelingLayout(unittest.TestCase):
             form.findChild(QtWidgets.QSpinBox, "input_points_per_side")
         )
         self.assertIsNone(form.findChild(QtWidgets.QSpinBox, "input_min_area"))
+
+    def test_visual_prompt_controls_are_part_of_existing_panel(self):
+        form = QtWidgets.QWidget()
+        self._widgets.append(form)
+        ui_path = (
+            Path(__file__).resolve().parents[2]
+            / "anylabeling/views/labeling/widgets/auto_labeling/auto_labeling.ui"
+        )
+        uic.loadUi(str(ui_path), form)
+
+        self.assertIsInstance(
+            form.button_generate_visual_prompt, QtWidgets.QPushButton
+        )
+        self.assertIsInstance(
+            form.visual_prompt_status_label, QtWidgets.QLabel
+        )
+        self.assertIsInstance(
+            form.button_clear_visual_prompt, QtWidgets.QPushButton
+        )
+        self.assertIsInstance(
+            form.button_save_visual_prompt, QtWidgets.QPushButton
+        )
+        self.assertIsInstance(
+            form.button_load_visual_prompt, QtWidgets.QPushButton
+        )
+
+    def test_visual_prompt_replacement_clears_temporary_marks(self):
+        config.current_config_file = (
+            "anylabeling/configs/xanylabeling_config.yaml"
+        )
+        parent = type(
+            "Parent",
+            (),
+            {
+                "_config": get_config(),
+                "filename": "reference.jpg",
+                "image": object(),
+                "new_shapes_from_auto_labeling": lambda _self, _result: None,
+            },
+        )()
+        widget = AutoLabelingWidget(parent)
+        self._widgets.append(widget)
+        clears = []
+        widget.clear_auto_labeling_action_requested.connect(
+            lambda: clears.append(True)
+        )
+
+        widget.on_visual_prompt_status_changed(
+            {
+                "state": "REFERENCE_MARKS_READY",
+                "ready": True,
+                "mark_count": 2,
+            }
+        )
+        widget.on_visual_prompt_status_changed(
+            {
+                "state": "VISUAL_PROMPT_READY",
+                "ready": True,
+                "classes": ["object"],
+                "instance_count": 2,
+            }
+        )
+
+        self.assertEqual(clears, [True])
 
     def test_amg_requires_confirmation_once_per_session(self):
         widget = Mock()

--- a/tests/test_auto_labeling/test_yoloe_batch.py
+++ b/tests/test_auto_labeling/test_yoloe_batch.py
@@ -1,0 +1,204 @@
+import json
+import os
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PIL import Image
+from PyQt6 import QtWidgets
+
+from anylabeling.services.auto_labeling.types import AutoLabelingResult
+from anylabeling.views.labeling.utils import batch
+
+
+def make_app(tmp_path, manager, image_names):
+    input_dir = tmp_path / "images"
+    output_dir = tmp_path / "labels"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    image_paths = []
+    for name in image_names:
+        path = input_dir / name
+        Image.new("RGB", (32, 24), "white").save(path)
+        image_paths.append(str(path))
+    return (
+        SimpleNamespace(
+            auto_labeling_widget=SimpleNamespace(model_manager=manager),
+            image=True,
+            output_dir=str(output_dir),
+            _config={"store_data": False},
+            cancel_processing=False,
+            image_index=0,
+        ),
+        image_paths,
+        output_dir,
+    )
+
+
+def test_visual_prompt_batch_continues_after_broken_image(tmp_path):
+    calls = []
+
+    def predict(_image, filename, **kwargs):
+        calls.append((filename, kwargs))
+        if filename.endswith("broken.jpg"):
+            raise RuntimeError("broken image")
+        return AutoLabelingResult([], replace=True)
+
+    manager = Mock()
+    manager.predict_shapes.side_effect = predict
+    app, images, output_dir = make_app(
+        tmp_path, manager, ["one.jpg", "broken.jpg", "three.jpg"]
+    )
+    broken_label = output_dir / "broken.json"
+    broken_label.write_text('{"sentinel": true}', encoding="utf-8")
+
+    progress = []
+    failures = []
+    finished = []
+    worker = batch.BatchProcessingThread(
+        app,
+        images,
+        0,
+        "yoloe",
+        "",
+        False,
+        False,
+        visual_prompt=True,
+    )
+    worker.progress_updated.connect(
+        lambda value, _label: progress.append(value)
+    )
+    worker.image_failed.connect(
+        lambda filename, message: failures.append((filename, message))
+    )
+    worker.processing_finished.connect(
+        lambda count, cancelled: finished.append((count, cancelled))
+    )
+
+    worker.run()
+
+    assert len(calls) == 3
+    assert all(call[1]["visual_prompt"] for call in calls)
+    assert progress == [1, 2, 3]
+    assert finished == [(1, False)]
+    assert failures == [(images[1], "broken image")]
+    assert (output_dir / "one.json").is_file()
+    assert (output_dir / "three.json").is_file()
+    assert json.loads(broken_label.read_text(encoding="utf-8")) == {
+        "sentinel": True
+    }
+
+
+def test_visual_prompt_batch_honors_cancel_before_next_image(tmp_path):
+    manager = Mock()
+    app, images, _output_dir = make_app(tmp_path, manager, ["one.jpg"])
+    app.cancel_processing = True
+    finished = []
+    worker = batch.BatchProcessingThread(
+        app,
+        images,
+        0,
+        "yoloe",
+        "",
+        False,
+        False,
+        visual_prompt=True,
+    )
+    worker.processing_finished.connect(
+        lambda count, cancelled: finished.append((count, cancelled))
+    )
+
+    worker.run()
+
+    manager.predict_shapes.assert_not_called()
+    assert finished == [(0, True)]
+
+
+def test_visual_prompt_batch_stops_between_images_after_cancel(tmp_path):
+    manager = Mock()
+    app, images, _output_dir = make_app(
+        tmp_path, manager, ["one.jpg", "two.jpg"]
+    )
+
+    def predict(*_args, **_kwargs):
+        app.cancel_processing = True
+        return AutoLabelingResult([])
+
+    manager.predict_shapes.side_effect = predict
+    progress = []
+    finished = []
+    worker = batch.BatchProcessingThread(
+        app,
+        images,
+        0,
+        "yoloe",
+        "",
+        False,
+        False,
+        visual_prompt=True,
+    )
+    worker.progress_updated.connect(
+        lambda value, _label: progress.append(value)
+    )
+    worker.processing_finished.connect(
+        lambda count, cancelled: finished.append((count, cancelled))
+    )
+
+    worker.run()
+
+    assert manager.predict_shapes.call_count == 1
+    assert progress == [1]
+    assert finished == [(0, True)]
+
+
+def test_yoloe_batch_dialog_prefers_ready_visual_prompt():
+    app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    dialog = batch.YoloeBatchPromptDialog(visual_prompt_ready=True)
+    try:
+        assert dialog.mode_combo.currentData() == dialog.VISUAL_PROMPT
+        assert not dialog.text_input.isEnabled()
+        dialog.mode_combo.setCurrentIndex(
+            dialog.mode_combo.findData(dialog.TEXT_PROMPT)
+        )
+        app.processEvents()
+        assert dialog.text_input.isEnabled()
+    finally:
+        dialog.close()
+
+
+def test_run_all_images_visual_prompt_starts_at_folder_beginning():
+    qt_app = QtWidgets.QApplication.instance() or QtWidgets.QApplication([])
+    model = Mock()
+    model.has_visual_prompt.return_value = True
+    manager = Mock()
+    manager.loaded_model_config = {"type": "yoloe", "model": model}
+    app = QtWidgets.QWidget()
+    app._batch_processing_active = False
+    app.image_list = ["one.jpg", "two.jpg", "three.jpg"]
+    app.filename = "three.jpg"
+    app.fn_to_index = {"one.jpg": 0, "two.jpg": 1, "three.jpg": 2}
+    app.auto_labeling_widget = SimpleNamespace(model_manager=manager)
+    selection = (batch.YoloeBatchPromptDialog.VISUAL_PROMPT, "")
+
+    with (
+        patch.object(
+            batch.QtWidgets.QMessageBox,
+            "exec",
+            return_value=batch.QtWidgets.QMessageBox.StandardButton.Ok,
+        ),
+        patch.object(
+            batch.YoloeBatchPromptDialog,
+            "get_selection",
+            return_value=selection,
+        ),
+        patch.object(batch, "_start_batch_processing") as start,
+    ):
+        batch.run_all_images(app)
+
+    assert app.current_index == 2
+    assert app.image_index == 0
+    assert app.batch_visual_prompt
+    start.assert_called_once_with(app)
+    app.close()
+    qt_app.processEvents()

--- a/tests/test_models/test_visual_prompt_profile.py
+++ b/tests/test_models/test_visual_prompt_profile.py
@@ -1,0 +1,158 @@
+import hashlib
+import json
+import os
+import tempfile
+import unittest
+
+import numpy as np
+
+from anylabeling.services.auto_labeling.visual_prompt_profile import (
+    EMBEDDING_FILENAME,
+    METADATA_FILENAME,
+    VisualPromptCompatibilityError,
+    VisualPromptProfile,
+    VisualPromptProfileError,
+)
+
+
+class TestVisualPromptProfile(unittest.TestCase):
+    @staticmethod
+    def make_profile(name="product_A"):
+        return VisualPromptProfile.create(
+            name=name,
+            model_name="yoloe-11s-seg",
+            model_signature={
+                "model_type": "yoloe",
+                "model_name": "yoloe-11s-seg",
+                "model_path": "/models/yoloe-11s-seg.pt",
+                "model_file": "yoloe-11s-seg.pt",
+                "model_size": 123456,
+                "architecture": "YOLOEModel",
+                "embedding_dimension": 512,
+            },
+            reference={
+                "image_path": "/data/reference.jpg",
+                "image_size": [640, 480],
+                "boxes": [[10.0, 20.0, 100.0, 120.0]],
+                "instance_count": 1,
+                "classes": ["object"],
+            },
+            classes=["object"],
+            vpe=np.ones((1, 1, 512), dtype=np.float32),
+        )
+
+    def test_round_trip_uses_json_and_npz_without_pickle(self):
+        profile = self.make_profile()
+        with tempfile.TemporaryDirectory() as directory:
+            metadata_path = profile.save(directory)
+            restored = VisualPromptProfile.load(metadata_path)
+
+            self.assertEqual(
+                metadata_path, os.path.join(directory, METADATA_FILENAME)
+            )
+            self.assertEqual(restored.name, "product_A")
+            self.assertEqual(restored.reference, profile.reference)
+            self.assertEqual(restored.vpe.dtype, np.float32)
+            np.testing.assert_array_equal(restored.vpe, profile.vpe)
+            with np.load(
+                os.path.join(directory, EMBEDDING_FILENAME),
+                allow_pickle=False,
+            ) as archive:
+                self.assertEqual(archive.files, ["vpe"])
+
+    def test_rejects_invalid_profile_metadata(self):
+        invalid_profiles = (
+            self.make_profile("../escape"),
+            VisualPromptProfile(
+                **{**self.make_profile().__dict__, "version": 99}
+            ),
+            VisualPromptProfile(
+                **{
+                    **self.make_profile().__dict__,
+                    "vpe": np.ones((1, 1, 512), dtype=np.float64),
+                }
+            ),
+            VisualPromptProfile(
+                **{
+                    **self.make_profile().__dict__,
+                    "reference": {"boxes": [[1, 1, 0, 2]]},
+                }
+            ),
+        )
+        for profile in invalid_profiles:
+            with self.subTest(name=profile.name, version=profile.version):
+                with self.assertRaises(VisualPromptProfileError):
+                    profile.validate()
+
+    def test_rejects_unsupported_version_before_loading_embedding(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.make_profile().save(directory)
+            metadata_path = os.path.join(directory, METADATA_FILENAME)
+            with open(metadata_path, encoding="utf-8") as file:
+                metadata = json.load(file)
+            metadata["version"] = 2
+            with open(metadata_path, "w", encoding="utf-8") as file:
+                json.dump(metadata, file)
+
+            with self.assertRaisesRegex(
+                VisualPromptProfileError, "Unsupported.*version"
+            ):
+                VisualPromptProfile.load(directory)
+
+    def test_rejects_corrupted_embedding_and_preserves_no_object_payload(self):
+        with tempfile.TemporaryDirectory() as directory:
+            self.make_profile().save(directory)
+            embedding_path = os.path.join(directory, EMBEDDING_FILENAME)
+            with open(embedding_path, "ab") as file:
+                file.write(b"corruption")
+
+            with self.assertRaisesRegex(VisualPromptProfileError, "checksum"):
+                VisualPromptProfile.load(directory)
+
+    def test_rejects_archive_shape_or_dtype_mismatch(self):
+        for vpe in (
+            np.ones((1, 1, 256), dtype=np.float32),
+            np.ones((1, 1, 512), dtype=np.float64),
+        ):
+            with self.subTest(shape=vpe.shape, dtype=vpe.dtype):
+                with tempfile.TemporaryDirectory() as directory:
+                    self.make_profile().save(directory)
+                    embedding_path = os.path.join(
+                        directory, EMBEDDING_FILENAME
+                    )
+                    np.savez_compressed(embedding_path, vpe=vpe)
+                    with open(embedding_path, "rb") as file:
+                        checksum = hashlib.sha256(file.read()).hexdigest()
+                    metadata_path = os.path.join(directory, METADATA_FILENAME)
+                    with open(metadata_path, encoding="utf-8") as file:
+                        metadata = json.load(file)
+                    metadata["embedding_sha256"] = checksum
+                    with open(metadata_path, "w", encoding="utf-8") as file:
+                        json.dump(metadata, file)
+
+                    with self.assertRaises(VisualPromptProfileError):
+                        VisualPromptProfile.load(directory)
+
+    def test_model_compatibility_checks_weights_architecture_and_dimension(
+        self,
+    ):
+        profile = self.make_profile()
+        compatible = dict(profile.model_signature)
+        self.assertTrue(profile.validate_compatibility(compatible))
+
+        for key, value in (
+            ("model_type", "other"),
+            ("model_file", "yoloe-11l-seg.pt"),
+            ("model_size", 999),
+            ("architecture", "OtherModel"),
+            ("embedding_dimension", 256),
+        ):
+            with self.subTest(key=key):
+                incompatible = dict(compatible)
+                incompatible[key] = value
+                with self.assertRaises(VisualPromptCompatibilityError):
+                    profile.validate_compatibility(incompatible)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_models/test_yoloe.py
+++ b/tests/test_models/test_yoloe.py
@@ -1,7 +1,12 @@
 import sys
+import tempfile
 import unittest
 from types import SimpleNamespace
 from unittest import mock
+
+import numpy as np
+import torch
+from PIL import Image
 
 from anylabeling.services.auto_labeling import yoloe
 
@@ -75,6 +80,242 @@ class TestYoloeEmbeddingModel(unittest.TestCase):
         inner_model.set_classes.assert_called_once_with(["cat"], "embeddings")
         inner_model.fuse.assert_called_once_with()
         self.assertEqual(vocab, ["first", "second"])
+
+
+class TestYoloeCrossImageVisualPrompt(unittest.TestCase):
+    @staticmethod
+    def make_model(embedding_dimension=512):
+        parameter = torch.nn.Parameter(torch.zeros(1))
+        inner_model = mock.Mock()
+        inner_model.parameters.side_effect = lambda: iter([parameter])
+        inner_model.model = [SimpleNamespace(embed=embedding_dimension)]
+        return SimpleNamespace(
+            model=inner_model,
+            predictor=object(),
+            predict=mock.Mock(return_value=["prediction"]),
+            set_classes=mock.Mock(),
+        )
+
+    @staticmethod
+    def make_instance(model=None):
+        instance = yoloe.YOLOE.__new__(yoloe.YOLOE)
+        instance.config = {
+            "type": "yoloe",
+            "name": "unit-test-yoloe",
+            "model_path": __file__,
+        }
+        instance.input_shape = (640, 640)
+        instance.conf_thres = 0.25
+        instance.iou_thres = 0.70
+        instance.replace = True
+        instance.marks = []
+        instance._cross_image_visual_model = model
+        instance.visual_prompt_vpe = None
+        instance.visual_prompt_classes = []
+        instance.visual_prompt_reference = None
+        instance.visual_prompt_model_signature = None
+        instance.visual_prompt_profile_name = None
+        instance.visual_prompt_state = yoloe.VisualPromptState.NO_VISUAL_PROMPT
+        return instance
+
+    def test_reference_box_validation(self):
+        boxes = yoloe.YOLOE.validate_reference_boxes(
+            [[1, 2, 10, 20]], (100, 80)
+        )
+        self.assertEqual(boxes.dtype, np.float32)
+        np.testing.assert_array_equal(boxes, [[1, 2, 10, 20]])
+
+        invalid_boxes = (
+            [],
+            [[1, 2, 1, 20]],
+            [[-1, 2, 10, 20]],
+            [[1, 2, 101, 20]],
+            [[1, 2, np.nan, 20]],
+        )
+        for invalid in invalid_boxes:
+            with self.subTest(invalid=invalid):
+                with self.assertRaises(ValueError):
+                    yoloe.YOLOE.validate_reference_boxes(invalid, (100, 80))
+
+    def test_marks_update_visual_prompt_state(self):
+        instance = self.make_instance()
+
+        instance.set_auto_labeling_marks(
+            [{"type": "rectangle", "data": [1, 2, 10, 20]}]
+        )
+        self.assertEqual(
+            instance.visual_prompt_state,
+            yoloe.VisualPromptState.REFERENCE_MARKS_READY,
+        )
+
+        instance.set_auto_labeling_marks([])
+        self.assertEqual(
+            instance.visual_prompt_state,
+            yoloe.VisualPromptState.NO_VISUAL_PROMPT,
+        )
+
+    def test_set_visual_prompt_validates_and_resets_predictor(self):
+        model = self.make_model()
+        instance = self.make_instance(model)
+        source_vpe = torch.ones(1, 1, 512, requires_grad=True)
+
+        instance.set_visual_prompt(
+            source_vpe,
+            ["object"],
+            {"image_path": "reference.jpg"},
+        )
+
+        self.assertTrue(instance.has_visual_prompt())
+        self.assertTrue(instance.visual_prompt_ready)
+        self.assertIsNone(model.predictor)
+        self.assertFalse(instance.visual_prompt_vpe.requires_grad)
+        self.assertIsNot(instance.visual_prompt_vpe, source_vpe)
+        model.set_classes.assert_called_once_with(
+            ["object"], instance.visual_prompt_vpe
+        )
+        self.assertEqual(
+            instance.get_visual_prompt_state(), "VISUAL_PROMPT_READY"
+        )
+        self.assertEqual(
+            instance.visual_prompt_model_signature["embedding_dimension"],
+            512,
+        )
+
+    def test_set_visual_prompt_rejects_incompatible_embeddings(self):
+        instance = self.make_instance(self.make_model())
+
+        invalid_embeddings = (
+            torch.ones(1, 512),
+            torch.ones(2, 1, 512),
+            torch.ones(1, 2, 512),
+            torch.ones(1, 1, 256),
+            torch.full((1, 1, 512), torch.nan),
+        )
+        for embedding in invalid_embeddings:
+            with self.subTest(shape=embedding.shape):
+                with self.assertRaises(ValueError):
+                    instance.set_visual_prompt(embedding, ["object"])
+
+        with self.assertRaises(TypeError):
+            instance.set_visual_prompt(torch.ones(1, 1, 512), "object")
+
+    def test_build_visual_prompt_resets_existing_predictor(self):
+        model = self.make_model()
+        instance = self.make_instance(model)
+        instance.marks = [
+            {"type": "rectangle", "data": [1, 2, 10, 20], "label": 1}
+        ]
+        generated_vpe = torch.ones(1, 1, 512)
+
+        def generate_vpe(**kwargs):
+            self.assertIsNone(model.predictor)
+            self.assertIs(kwargs["predictor"], yoloe.YOLOEVPSegPredictor)
+            self.assertTrue(kwargs["return_vpe"])
+            model.predictor = SimpleNamespace(vpe=generated_vpe)
+            return ["reference prediction"]
+
+        model.predict.side_effect = generate_vpe
+        vpe = instance.build_visual_prompt(Image.new("RGB", (100, 80)))
+
+        self.assertTrue(torch.equal(vpe, generated_vpe))
+        self.assertIsNone(model.predictor)
+        self.assertEqual(instance.marks, [])
+        self.assertEqual(
+            instance.visual_prompt_reference["boxes"],
+            [[1.0, 2.0, 10.0, 20.0]],
+        )
+
+    def test_target_prediction_keeps_cached_prompt_ready(self):
+        model = self.make_model()
+        instance = self.make_instance(model)
+        instance.postprocess = mock.Mock(return_value=["shape"])
+        instance.set_visual_prompt(torch.ones(1, 1, 512), ["object"])
+        cached_vpe = instance.visual_prompt_vpe
+
+        result = instance.predict_with_visual_prompt(
+            Image.new("RGB", (100, 80))
+        )
+
+        self.assertEqual(result.shapes, ["shape"])
+        self.assertIs(instance.visual_prompt_vpe, cached_vpe)
+        self.assertTrue(instance.has_visual_prompt())
+        self.assertEqual(
+            instance.visual_prompt_state,
+            yoloe.VisualPromptState.VISUAL_PROMPT_READY,
+        )
+
+    def test_clear_visual_prompt_does_not_clear_other_mode_models(self):
+        cross_model = self.make_model()
+        instance = self.make_instance(cross_model)
+        instance._text_model = object()
+        instance._visual_model = object()
+        instance._prompt_free_model = object()
+        instance.set_visual_prompt(torch.ones(1, 1, 512), ["object"])
+
+        instance.clear_visual_prompt()
+
+        self.assertFalse(instance.has_visual_prompt())
+        self.assertIsNone(instance._cross_image_visual_model)
+        self.assertIsNotNone(instance._text_model)
+        self.assertIsNotNone(instance._visual_model)
+        self.assertIsNotNone(instance._prompt_free_model)
+        self.assertEqual(
+            instance.visual_prompt_state,
+            yoloe.VisualPromptState.NO_VISUAL_PROMPT,
+        )
+
+    def test_profile_round_trip_restores_embedding_to_model_device(self):
+        model = self.make_model()
+        instance = self.make_instance(model)
+        instance.set_visual_prompt(
+            torch.ones(1, 1, 512),
+            ["object"],
+            {
+                "image_path": "reference.jpg",
+                "image_size": [100, 80],
+                "boxes": [[1.0, 2.0, 10.0, 20.0]],
+                "instance_count": 1,
+                "classes": ["object"],
+            },
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            instance.save_visual_prompt_profile("product_A", directory)
+            instance.clear_visual_prompt()
+            instance._cross_image_visual_model = model
+
+            profile = instance.load_visual_prompt_profile(directory)
+
+        self.assertEqual(profile.name, "product_A")
+        self.assertEqual(instance.visual_prompt_profile_name, "product_A")
+        self.assertEqual(instance.visual_prompt_vpe.device.type, "cpu")
+        self.assertEqual(instance.visual_prompt_vpe.dtype, torch.float32)
+        self.assertTrue(instance.has_visual_prompt())
+
+    def test_incompatible_profile_does_not_replace_cached_prompt(self):
+        model = self.make_model()
+        instance = self.make_instance(model)
+        instance.set_visual_prompt(
+            torch.ones(1, 1, 512),
+            ["object"],
+            {"boxes": [[1.0, 2.0, 10.0, 20.0]], "instance_count": 1},
+        )
+        cached_vpe = instance.visual_prompt_vpe
+        profile = SimpleNamespace(
+            vpe=np.ones((1, 1, 512), dtype=np.float32),
+            validate_compatibility=mock.Mock(
+                side_effect=ValueError("incompatible model")
+            ),
+        )
+
+        with mock.patch.object(
+            yoloe.VisualPromptProfile, "load", return_value=profile
+        ):
+            with self.assertRaisesRegex(ValueError, "incompatible model"):
+                instance.load_visual_prompt_profile("metadata.json")
+
+        self.assertIs(instance.visual_prompt_vpe, cached_vpe)
+        self.assertTrue(instance.has_visual_prompt())
+        model.set_classes.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/tests/test_models/test_yoloe_model_manager.py
+++ b/tests/test_models/test_yoloe_model_manager.py
@@ -1,0 +1,142 @@
+from unittest.mock import Mock
+
+import torch
+import pytest
+
+from anylabeling.services.auto_labeling.model_manager import ModelManager
+from anylabeling.services.auto_labeling.types import AutoLabelingResult
+
+
+class FakeYoloe:
+    def __init__(self):
+        self.marks = []
+        self.visual_prompt_vpe = None
+        self.visual_prompt_classes = []
+        self.visual_prompt_reference = None
+        self.state = "NO_VISUAL_PROMPT"
+
+    def set_auto_labeling_marks(self, marks):
+        self.marks = marks
+        self.state = "REFERENCE_MARKS_READY" if marks else "NO_VISUAL_PROMPT"
+
+    def build_visual_prompt(self, source):
+        assert source == "reference.jpg"
+        self.visual_prompt_vpe = torch.zeros(1, 1, 512)
+        self.visual_prompt_classes = ["object"]
+        self.visual_prompt_reference = {
+            "image_path": source,
+            "instance_count": len(self.marks),
+        }
+        self.marks = []
+        self.state = "VISUAL_PROMPT_READY"
+        return self.visual_prompt_vpe
+
+    def clear_visual_prompt(self):
+        self.visual_prompt_vpe = None
+        self.visual_prompt_classes = []
+        self.visual_prompt_reference = None
+        self.marks = []
+        self.state = "NO_VISUAL_PROMPT"
+
+    def has_visual_prompt(self):
+        return self.visual_prompt_vpe is not None
+
+    def get_visual_prompt_state(self):
+        return self.state
+
+
+def make_manager(monkeypatch):
+    monkeypatch.setattr(ModelManager, "load_model_configs", lambda self: None)
+    manager = ModelManager()
+    model = FakeYoloe()
+    manager.loaded_model_config = {"type": "yoloe", "model": model}
+    return manager, model
+
+
+def test_visual_prompt_status_tracks_marks_build_and_clear(monkeypatch):
+    manager, model = make_manager(monkeypatch)
+    statuses = []
+    messages = []
+    manager.visual_prompt_status_changed.connect(statuses.append)
+    manager.new_model_status.connect(messages.append)
+
+    manager.set_auto_labeling_marks(
+        [{"type": "rectangle", "data": [1, 2, 3, 4]}]
+    )
+    assert statuses[-1]["state"] == "REFERENCE_MARKS_READY"
+    assert statuses[-1]["mark_count"] == 1
+
+    manager.build_visual_prompt(reference_image=True, filename="reference.jpg")
+    assert statuses[-1] == {
+        "state": "VISUAL_PROMPT_READY",
+        "ready": True,
+        "classes": ["object"],
+        "reference_image": "reference.jpg",
+        "instance_count": 1,
+        "vpe_shape": [1, 1, 512],
+        "profile_name": None,
+        "mark_count": 0,
+    }
+    assert "generated successfully" in messages[-1]
+
+    assert manager.clear_visual_prompt()
+    assert statuses[-1]["state"] == "NO_VISUAL_PROMPT"
+    assert not statuses[-1]["ready"]
+    assert not model.has_visual_prompt()
+
+
+def test_visual_prompt_actions_reject_non_yoloe_model(monkeypatch):
+    monkeypatch.setattr(ModelManager, "load_model_configs", lambda self: None)
+    manager = ModelManager()
+    manager.loaded_model_config = {"type": "yolov8", "model": Mock()}
+    messages = []
+    finished = []
+    manager.new_model_status.connect(messages.append)
+    manager.prediction_finished.connect(lambda: finished.append(True))
+
+    manager.build_visual_prompt(reference_image=True, filename="reference.jpg")
+
+    assert "Load a YOLOE model" in messages[-1]
+    assert finished == [True]
+    assert not manager.clear_visual_prompt()
+
+
+def test_batch_visual_prompt_uses_cached_model_without_rebuilding(monkeypatch):
+    monkeypatch.setattr(ModelManager, "load_model_configs", lambda self: None)
+    manager = ModelManager()
+    model = Mock()
+    model.has_visual_prompt.return_value = True
+    expected = AutoLabelingResult([])
+    model.predict_shapes.return_value = expected
+    manager.loaded_model_config = {"type": "yoloe", "model": model}
+
+    result = manager.predict_shapes(
+        image=True,
+        filename="target.jpg",
+        batch=True,
+        visual_prompt=True,
+    )
+
+    assert result is expected
+    model.predict_shapes.assert_called_once_with(
+        True, "target.jpg", use_visual_prompt=True
+    )
+    model.build_visual_prompt.assert_not_called()
+    model.set_visual_prompt.assert_not_called()
+
+
+def test_batch_prediction_reraises_per_image_errors(monkeypatch):
+    monkeypatch.setattr(ModelManager, "load_model_configs", lambda self: None)
+    manager = ModelManager()
+    model = Mock()
+    model.has_visual_prompt.return_value = True
+    model.predict_shapes.side_effect = RuntimeError("damaged target")
+    manager.loaded_model_config = {"type": "yoloe", "model": model}
+
+    with pytest.raises(RuntimeError, match="damaged target"):
+        manager.predict_shapes(
+            image=True,
+            filename="broken.jpg",
+            batch=True,
+            visual_prompt=True,
+        )


### PR DESCRIPTION
Add cross-image VPE caching, threaded GUI controls, batch auto-labeling, safe JSON/NPZ profile persistence, integration tests, and MVP documentation.

Thanks for your contribution!  
Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [ ] I have read and agree to the CLA.
