### PR TITLE
fix: preserve edit mode after loading attributes

### DIFF
--- a/anylabeling/views/labeling/utils/upload.py
+++ b/anylabeling/views/labeling/utils/upload.py
@@ -1872,7 +1872,6 @@ def upload_shape_attrs_file(self, LABEL_OPACITY):
         else:
             self.hide_attributes_panel()
         self.canvas.h_shape_is_hovered = False
-        self._settings_runtime_applier.set_auto_switch_to_edit_mode(False)
 
         popup = Popup(
             self.tr(f"Uploading shape attributes file successfully!"),

--- a/tests/test_labeling/test_upload_shape_attributes.py
+++ b/tests/test_labeling/test_upload_shape_attributes.py
@@ -270,7 +270,7 @@ class TestUploadShapeAttributes(unittest.TestCase):
             widget.save_attributes.assert_called_once_with([shape])
             widget.hide_attributes_panel.assert_not_called()
 
-    def test_repeated_upload_keeps_auto_switch_signal_state_consistent(self):
+    def test_upload_preserves_auto_switch_signal_state(self):
         with tempfile.NamedTemporaryFile(
             mode="w", suffix=".json", encoding="utf-8"
         ) as file:
@@ -322,15 +322,24 @@ class TestUploadShapeAttributes(unittest.TestCase):
                             for call in calls
                         )
                     )
-                    self.assertFalse(widget._auto_switch_signal_connected)
+                    self.assertEqual(
+                        widget._auto_switch_signal_connected,
+                        initially_enabled,
+                    )
                     self.assertEqual(
                         widget._config["auto_switch_to_edit_mode"],
                         initially_enabled,
                     )
                     canvas.mode_changed.emit()
-                    set_edit_mode.assert_not_called()
+                    self.assertEqual(
+                        set_edit_mode.call_count,
+                        1 if initially_enabled else 0,
+                    )
 
                     applier.set_auto_switch_to_edit_mode(True)
                     canvas.mode_changed.emit()
 
-                    set_edit_mode.assert_called_once_with()
+                    self.assertEqual(
+                        set_edit_mode.call_count,
+                        2 if initially_enabled else 1,
+                    )


### PR DESCRIPTION
## Summary

- Preserve the configured auto-switch-to-edit-mode signal after importing a shape attributes file.
- Cover both enabled and disabled settings across repeated imports.

Fixes #1444

## Tests

- `python -m pytest -q tests/test_labeling/test_upload_shape_attributes.py` (5 passed, 13 subtests passed)
- `git diff --check`

Please confirm that you agree to the [Contributor License Agreement (CLA)](../CLA.md) by checking the box below:

- [ ] I have read and agree to the CLA.
