### PR TITLE
chore(converter): remove unused standalone entry point

### DIFF
--- a/anylabeling/views/common/converter.py
+++ b/anylabeling/views/common/converter.py
@@ -1514,7 +1514,3 @@ def run_conversion(
 
         traceback.print_exc()
         sys.exit(1)
-
-
-if __name__ == "__main__":
-    run_conversion()


### PR DESCRIPTION
### Problem

`anylabeling/views/common/converter.py` ends with:

```python
if __name__ == "__main__":
    run_conversion()
```

but `run_conversion` is defined as:

```python
def run_conversion(
    task,
    images=None,
    ...
):
```

`task` is a required positional argument, so running the module directly
(`python anylabeling/views/common/converter.py`) can only ever raise:

```
TypeError: run_conversion() missing 1 required positional argument: 'task'
```

There is no code path in which this block does anything useful.

### Fix

The actual CLI entry point is the `convert` subcommand wired up in
`anylabeling/app.py` (argparse → `handle_convert_command`), which validates
the task and calls `run_conversion(task, ...)` with the parsed arguments.
The bare `__main__` block in `converter.py` is a vestigial leftover that only
misleads anyone who tries to run the file directly, so this PR removes it.

No behavior change for the real CLI path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
