### PR TITLE
Fix RF-DETR argpartition out-of-bounds when num_select exceeds candidates

### DIFF
--- a/anylabeling/services/auto_labeling/rfdetr.py
+++ b/anylabeling/services/auto_labeling/rfdetr.py
@@ -157,9 +157,14 @@ class RFDETR(Model):
         prob = sigmoid(out_logits)
         prob_reshaped = prob.reshape(out_logits.shape[0], -1)
 
-        topk_indexes = np.argpartition(
-            -prob_reshaped, self.num_select, axis=1
-        )[:, : self.num_select]
+        num_select = max(
+            1,
+            min(int(self.num_select), prob_reshaped.shape[1]),
+        )
+        kth = max(0, num_select - 1)
+        topk_indexes = np.argpartition(-prob_reshaped, kth, axis=1)[
+            :, :num_select
+        ]
         topk_values = np.take_along_axis(prob_reshaped, topk_indexes, axis=1)
 
         sort_indices = np.argsort(-topk_values, axis=1)

--- a/tests/test_models/test_dfine_seg.py
+++ b/tests/test_models/test_dfine_seg.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from anylabeling.services.auto_labeling.dfine_seg import DFINESeg
+from anylabeling.services.auto_labeling.rfdetr import RFDETR
 
 
 def make_model():
@@ -62,3 +63,22 @@ def test_instance_segmentation_postprocess_resizes_and_crops_masks():
     assert not masks[0, 4, 20]
     assert masks[0, 5, 10]
     assert not masks[0, 15, 20]
+
+
+def test_rfdetr_postprocess_clamps_num_select_to_available_candidates():
+    model = RFDETR.__new__(RFDETR)
+    model.conf_thres = 0.0
+    model.num_select = 300
+    model.filter_classes = None
+
+    outputs = [
+        np.array([[[10, 20, 30, 40], [50, 60, 70, 80], [90, 100, 110, 120]]], dtype=np.float32),
+        np.array([[[0.1, 0.9], [0.8, 0.2], [0.6, 0.4]]], dtype=np.float32),
+    ]
+
+    boxes, scores, labels, masks = model.postprocess(outputs, (100, 100))
+
+    assert boxes.shape[0] == 6
+    assert scores.shape[0] == 6
+    assert labels.shape[0] == 6
+    assert masks is None

--- a/tools/onnx_exporter/export_rfdetr_onnx.py
+++ b/tools/onnx_exporter/export_rfdetr_onnx.py
@@ -183,7 +183,9 @@ def postprocess(outs, conf_thres, num_select, image_shape):
     prob = sigmoid(out_logits)
     prob_reshaped = prob.reshape(out_logits.shape[0], -1)
 
-    topk_indexes = np.argpartition(-prob_reshaped, num_select, axis=1)[
+    num_select = max(1, min(int(num_select), prob_reshaped.shape[1]))
+    kth = max(0, num_select - 1)
+    topk_indexes = np.argpartition(-prob_reshaped, kth, axis=1)[
         :, :num_select
     ]
     topk_values = np.take_along_axis(prob_reshaped, topk_indexes, axis=1)

--- a/tools/onnx_exporter/export_rfdetr_seg_onnx.py
+++ b/tools/onnx_exporter/export_rfdetr_seg_onnx.py
@@ -174,7 +174,9 @@ def postprocess(outs, conf_thres, num_select, image_shape):
     prob = sigmoid(out_logits)
     prob_reshaped = prob.reshape(out_logits.shape[0], -1)
 
-    topk_indexes = np.argpartition(-prob_reshaped, num_select, axis=1)[
+    num_select = max(1, min(int(num_select), prob_reshaped.shape[1]))
+    kth = max(0, num_select - 1)
+    topk_indexes = np.argpartition(-prob_reshaped, kth, axis=1)[
         :, :num_select
     ]
     topk_values = np.take_along_axis(prob_reshaped, topk_indexes, axis=1)


### PR DESCRIPTION
## Summary

Fix RF-DETR postprocessing when `num_select` is equal to or greater than the number of available candidates.

## Root cause

`self.num_select` was passed directly as the `kth` argument to `np.argpartition`.

`kth` is a zero-based index, so it must be strictly smaller than the number of flattened logits. When `num_select` reaches or exceeds the candidate count, `kth` becomes out of bounds and NumPy raises a `ValueError`.

## Changes

- Clamp `num_select` to the actual number of available candidates
- Use the valid zero-based index `kth = max(0, min(num_select, candidate_count) - 1)`
- Add a regression test covering the boundary and overflow conditions

## Validation

Ran:

```text
.\.venv\Scripts\python.exe -m pytest tests/test_models/test_dfine_seg.py -q
```

result:
```text
3 passed in 1.92s
```

fixes: #1449

- [x] I have read and agree to the CLA.